### PR TITLE
Set freed pointers to NULL

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -496,8 +496,8 @@ void ws2811_cleanup(ws2811_t *ws2811)
         if (ws2811->channel[chan].leds)
         {
             free(ws2811->channel[chan].leds);
-            ws2811->channel[chan].leds = NULL;
         }
+        ws2811->channel[chan].leds = NULL;
     }
 
     ws2811_device_t *device = ws2811->device;


### PR DESCRIPTION
Calling the `ws2811_cleanup` method more than once results in a segmentation fault. This situation can arise if the library is used without sufficient privileges to access the DMA space via `/dev/mem`. When the `ws2811_init` method fails it will (in some instances) invoke `ws2811_cleanup`. If the user then calls `ws2811_fini` before exiting the program a segmentation fault results.

The `ws2811_cleanup` code already checks for a `NULL` pointer before calling `free` on the memory. This change just sets pointers to `NULL` _after_ free has been called. This allows `ws2811_cleanup` to be called multiple times without incident.
