### PR TITLE
Add brightness control

### DIFF
--- a/main.c
+++ b/main.c
@@ -69,12 +69,14 @@ ws2811_t ledstring =
             .gpionum = GPIO_PIN,
             .count = LED_COUNT,
             .invert = 0,
+            .brightness = 255,
         },
         [1] =
         {
             .gpionum = 0,
             .count = 0,
             .invert = 0,
+            .brightness = 0,
         },
     },
 };

--- a/python/examples/lowlevel.py
+++ b/python/examples/lowlevel.py
@@ -17,6 +17,7 @@ LED_COUNT      = 16         # How many LEDs to light.
 LED_FREQ_HZ    = 800000     # Frequency of the LED signal.  Should be 800khz or 400khz.
 LED_DMA_NUM    = 5          # DMA channel to use, can be 0-14.
 LED_GPIO       = 18         # GPIO connected to the LED signal line.  Must support PWM!
+LED_BRIGHTNESS = 255        # Set to 0 for darkest and 255 for brightest
 LED_INVERT     = 0          # Set to 1 to invert the LED signal, good if using NPN
 							# transistor as a 3.3V->5V level converter.  Keep at 0
 							# for a normal/non-inverted signal.
@@ -45,12 +46,14 @@ for channum in range(2):
     ws.ws2811_channel_t_count_set(channel, 0)
     ws.ws2811_channel_t_gpionum_set(channel, 0)
     ws.ws2811_channel_t_invert_set(channel, 0)
+    ws.ws2811_channel_t_brightness_set(channel, 0)
 
 channel = ws.ws2811_channel_get(leds, LED_CHANNEL)
 
 ws.ws2811_channel_t_count_set(channel, LED_COUNT)
 ws.ws2811_channel_t_gpionum_set(channel, LED_GPIO)
 ws.ws2811_channel_t_invert_set(channel, LED_INVERT)
+ws.ws2811_channel_t_brightness_set(channel, LED_BRIGHTNESS)
 
 ws.ws2811_t_freq_set(leds, LED_FREQ_HZ)
 ws.ws2811_t_dmanum_set(leds, LED_DMA_NUM)

--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -9,11 +9,12 @@ from neopixel import *
 
 
 # LED strip configuration:
-LED_COUNT   = 16      # Number of LED pixels.
-LED_PIN     = 18      # GPIO pin connected to the pixels (must support PWM!).
-LED_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA     = 5       # DMA channel to use for generating signal (try 5)
-LED_INVERT  = False   # True to invert the signal (when using NPN transistor level shift)
+LED_COUNT      = 16      # Number of LED pixels.
+LED_PIN        = 18      # GPIO pin connected to the pixels (must support PWM!).
+LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
+LED_DMA        = 5       # DMA channel to use for generating signal (try 5)
+LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
+LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 
 
 # Define functions which animate LEDs in various ways.
@@ -77,7 +78,7 @@ def theaterChaseRainbow(strip, wait_ms=50):
 # Main program logic follows:
 if __name__ == '__main__':
 	# Create NeoPixel object with appropriate configuration.
-	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT)
+	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS)
 	# Intialize the library (must be called once before other functions).
 	strip.begin()
 

--- a/python/neopixel.py
+++ b/python/neopixel.py
@@ -121,9 +121,7 @@ class Adafruit_NeoPixel(object):
 		"""Scale each LED in the buffer by the provided brightness.  A brightness
 		of 0 is the darkest and 255 is the brightest.
 		"""
-		for channum in range(2):
-			chan = ws.ws2811_channel_get(self._leds, channum)
-			ws.ws2811_channel_t_brightness_set(chan, brightness)
+		ws.ws2811_channel_t_brightness_set(self._channel, brightness)
 
 	def getPixels(self):
 		"""Return an object which allows access to the LED display data as if 

--- a/python/neopixel.py
+++ b/python/neopixel.py
@@ -48,7 +48,7 @@ class _LED_Data(object):
 
 
 class Adafruit_NeoPixel(object):
-	def __init__(self, num, pin, freq_hz=800000, dma=5, invert=False, channel=0):
+	def __init__(self, num, pin, freq_hz=800000, dma=5, invert=False, brightness=255, channel=0):
 		"""Class to represent a NeoPixel/WS281x LED display.  Num should be the
 		number of pixels in the display, and pin should be the GPIO pin connected
 		to the display signal line (must be a PWM pin like 18!).  Optional
@@ -66,14 +66,14 @@ class Adafruit_NeoPixel(object):
 			ws.ws2811_channel_t_count_set(chan, 0)
 			ws.ws2811_channel_t_gpionum_set(chan, 0)
 			ws.ws2811_channel_t_invert_set(chan, 0)
-			# Start at full brightness.
-			ws.ws2811_channel_t_brightness_set(chan, 255)
+			ws.ws2811_channel_t_brightness_set(chan, 0)
 
 		# Initialize the channel in use
 		self._channel = ws.ws2811_channel_get(self._leds, channel)
 		ws.ws2811_channel_t_count_set(self._channel, num)
 		ws.ws2811_channel_t_gpionum_set(self._channel, pin)
 		ws.ws2811_channel_t_invert_set(self._channel, 0 if not invert else 1)
+		ws.ws2811_channel_t_brightness_set(self._channel, brightness)
 
 		# Initialize the controller
 		ws.ws2811_t_freq_set(self._leds, freq_hz)

--- a/ws2811.c
+++ b/ws2811.c
@@ -689,14 +689,15 @@ int ws2811_render(ws2811_t *ws2811)
     {
         ws2811_channel_t *channel = &ws2811->channel[chan];
         int wordpos = chan;
+        int scale   = (channel->brightness & 0xff) + 1;
 
         for (i = 0; i < channel->count; i++)                // Led
         {
             uint8_t color[] =
             {
-                (channel->leds[i] >> 8) & 0xff,             // green
-                (channel->leds[i] >> 16) & 0xff,            // red
-                (channel->leds[i] >> 0) & 0xff,             // blue
+                (((channel->leds[i] >> 8)  & 0xff) * scale) >> 8, // green
+                (((channel->leds[i] >> 16) & 0xff) * scale) >> 8, // red
+                (((channel->leds[i] >> 0)  & 0xff) * scale) >> 8, // blue
             };
 
             for (j = 0; j < ARRAY_SIZE(color); j++)        // Color

--- a/ws2811.h
+++ b/ws2811.h
@@ -45,6 +45,7 @@ typedef struct
     int gpionum;                                 //< GPIO Pin with PWM alternate function, 0 if unused
     int invert;                                  //< Invert output signal
     int count;                                   //< Number of LEDs, 0 if channel is unused
+    int brightness;                              //< Brightness value between 0 and 255
     ws2811_led_t *leds;                          //< LED buffers, allocated by driver based on count
 } ws2811_channel_t;
 


### PR DESCRIPTION
The arduino library for neo pixels is quite nice in that it has a brightness control. This is a simple scaling that is applied to each pixel to control the overall luminosity of the pixel. This is an implementation of brightness for the raspberry pi library.

The leds array for the channel is unaffected by these changes. The brightness scaling is applied to each led as the colors are rendered to the PWM channel.