### PR TITLE
minor fixes to compile without errors using gyp build-tools

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -592,7 +592,7 @@ int ws2811_init(ws2811_t *ws2811)
 
     // Cache the DMA control block bus address
     device->dma_cb_addr = addr_to_bus(device->dma_cb);
-    if (device->dma_cb_addr == (unsigned long)0L)
+    if (device->dma_cb_addr == (unsigned long)~0L)
     {
         goto err;
     }


### PR DESCRIPTION
Adds some explicit type-casts to prevent warnings when building with gyp in the node.js-module https://github.com/raspberry-node/node-rpi-ws281x-native 