### PR TITLE
minor fixes to prevent compiler-warnings when building with gyp

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -42,7 +42,7 @@
 
 
 // DMA address mapping by DMA number index
-const static uint32_t dma_addr[] =
+static const uint32_t dma_addr[] =
 {
     DMA0,
     DMA1,
@@ -146,7 +146,7 @@ void *dma_alloc(dma_page_t *head, uint32_t size)
         return NULL;
     }
 
-    for (i = 0; i < pages; i++)
+    for (i = 0; i < (int)pages; i++)
     {
         if (!dma_page_add(head, &vaddr[PAGE_SIZE * i]))
         {

--- a/ws2811.c
+++ b/ws2811.c
@@ -362,7 +362,7 @@ static int setup_pwm(ws2811_t *ws2811)
                      RPI_DMA_TI_SRC_INC;          // Increment src addr
 
         dma_cb->source_ad = addr_to_bus(page->addr);
-        if (dma_cb->source_ad == ~0L)
+        if (dma_cb->source_ad == (unsigned long)~0L)
         {
             return -1;
         }
@@ -595,7 +595,7 @@ int ws2811_init(ws2811_t *ws2811)
 
     // Cache the DMA control block bus address
     device->dma_cb_addr = addr_to_bus(device->dma_cb);
-    if (device->dma_cb_addr == ~0L)
+    if (device->dma_cb_addr == (unsigned long)~0L)
     {
         goto err;
     }
@@ -701,7 +701,7 @@ int ws2811_render(ws2811_t *ws2811)
                 (((channel->leds[i] >> 0)  & 0xff) * scale) >> 8, // blue
             };
 
-            for (j = 0; j < ARRAY_SIZE(color); j++)        // Color
+            for (j = 0; j < (int) ARRAY_SIZE(color); j++)        // Color
             {
                 for (k = 7; k >= 0; k--)                   // Bit
                 {


### PR DESCRIPTION
this is an updated version of pull-request #19. I had some problems with my raspberry and wasn't able to properly test the outcome of this, so it took a while for me to get it going again. Sorry about that.

As already said, when building your code with the `node-gyp`-toolchain for my node.js-module (https://github.com/raspberry-node/node-rpi-ws281x-native), there are some compiler-warnings from the files `ws2811.c` and `dma.c` (compiled on raspbian (wheezy) with gcc (Debian 4.6.3-14+rpi1)):
```
# ws2811.c

cc '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64'
  -I/root/.node-gyp/0.10.33/src -I/root/.node-gyp/0.10.33/deps/uv/include 
  -I/root/.node-gyp/0.10.33/deps/v8/include  -fPIC 
  -Wall -Wextra -Wno-unused-parameter -pthread -O2 -Wall 
  -O2 -fno-strict-aliasing -fno-tree-vrp -fno-omit-frame-pointer  
  -MMD -MF ./Release/.deps/Release/obj.target/libws2811/src/rpi_ws281x/ws2811.o.d.raw  
  -c -o Release/obj.target/libws2811/src/rpi_ws281x/ws2811.o ../src/rpi_ws281x/ws2811.c
../src/rpi_ws281x/ws2811.c: In function ‘setup_pwm’:
../src/rpi_ws281x/ws2811.c:365:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
../src/rpi_ws281x/ws2811.c: In function ‘ws2811_init’:
../src/rpi_ws281x/ws2811.c:598:29: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
../src/rpi_ws281x/ws2811.c: In function ‘ws2811_render’:
../src/rpi_ws281x/ws2811.c:704:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

# dma.c

cc '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' 
  -I/root/.node-gyp/0.10.33/src -I/root/.node-gyp/0.10.33/deps/uv/include 
  -I/root/.node-gyp/0.10.33/deps/v8/include  -fPIC 
  -Wall -Wextra -Wno-unused-parameter -pthread -O2 -Wall 
  -O2 -fno-strict-aliasing -fno-tree-vrp -fno-omit-frame-pointer  
  -MMD -MF ./Release/.deps/Release/obj.target/libws2811/src/rpi_ws281x/dma.o.d.raw  
  -c -o Release/obj.target/libws2811/src/rpi_ws281x/dma.o ../src/rpi_ws281x/dma.c
../src/rpi_ws281x/dma.c:45:1: warning: ‘static’ is not at beginning of declaration [-Wold-style-declaration]
../src/rpi_ws281x/dma.c: In function ‘dma_alloc’:
../src/rpi_ws281x/dma.c:149:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```

these changes add some explicit typecasts and a stylistic change to make these warnings go away.