### PR TITLE
Modify SCONS config to emit shared library also (if requested)

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -42,6 +42,8 @@ lib_srcs = Split('''
 ws2811_lib = tools_env.Library('libws2811', lib_srcs)
 tools_env['LIBS'].append(ws2811_lib)
 
+# Shared library (if required)
+ws2811_slib = tools_env.SharedLibrary('libws2811', lib_srcs)
 
 # Test Program
 srcs = Split('''


### PR DESCRIPTION
I added an additional target into SCONS to build as a shared library. It's not added to the default build target, but means you can do 'scons libws2811.so'.

I'm using this in my fork as my build process needs the shared object to use with a .net wrapper.