### PR TITLE
Several fixes and feature additions

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -42,7 +42,7 @@
 
 
 // DMA address mapping by DMA number index
-const static uint32_t dma_offset[] =
+static const uint32_t dma_offset[] =
 {
     DMA0_OFFSET,
     DMA1_OFFSET,

--- a/mailbox.c
+++ b/mailbox.c
@@ -135,7 +135,7 @@ unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
    p[0] = i*sizeof *p; // actual size
 
    if (mbox_property(file_desc, p) < 0)
-      return -1;
+      return 0;
    else
       return p[5];
 }

--- a/rpihw.c
+++ b/rpihw.c
@@ -211,7 +211,7 @@ const rpi_hw_t *rpi_hw_detect(void)
         {
             uint32_t rev;
             char *substr;
-            int i;
+            unsigned i;
 
             substr = strstr(line, ": ");
             if (!substr)

--- a/rpihw.c
+++ b/rpihw.c
@@ -47,7 +47,7 @@
 #define VIDEOCORE_BASE_RPI2                      0xc0000000
 
 
-const static rpi_hw_t rpi_hw_info[] = {
+static const rpi_hw_t rpi_hw_info[] = {
     //
     // Model B Rev 1.0
     //

--- a/ws2811.c
+++ b/ws2811.c
@@ -279,6 +279,14 @@ static int setup_pwm(ws2811_t *ws2811)
     usleep(10);
     pwm->ctl = RPI_PWM_CTL_USEF1 | RPI_PWM_CTL_MODE1 |
                RPI_PWM_CTL_USEF2 | RPI_PWM_CTL_MODE2;
+    if (ws2811->channel[0].invert)
+    {
+        pwm->ctl |= RPI_PWM_CTL_POLA1;
+    }
+    if (ws2811->channel[1].invert)
+    {
+        pwm->ctl |= RPI_PWM_CTL_POLA2;
+    }
     usleep(10);
     pwm->ctl |= RPI_PWM_CTL_PWEN1 | RPI_PWM_CTL_PWEN2;
 
@@ -364,8 +372,8 @@ static int gpio_init(ws2811_t *ws2811)
 }
 
 /**
- * Initialize the PWM DMA buffer with all zeros for non-inverted operation, or
- * ones for inverted operation.  The DMA buffer length is assumed to be a word 
+ * Initialize the PWM DMA buffer with all zeros, inverted operation will be
+ * handled by hardware.  The DMA buffer length is assumed to be a word
  * multiple.
  *
  * @param    ws2811  ws2811 instance pointer.
@@ -387,15 +395,7 @@ void pwm_raw_init(ws2811_t *ws2811)
 
         for (i = 0; i < wordcount; i++)
         {
-            if (channel->invert)
-            {
-                pwm_raw[wordpos] = ~0L;
-            }
-            else
-            {
-                pwm_raw[wordpos] = 0x0;
-            }
-
+            pwm_raw[wordpos] = 0x0;
             wordpos += 2;
         }
     }
@@ -652,11 +652,6 @@ int ws2811_render(ws2811_t *ws2811)
                     if (color[j] & (1 << k))
                     {
                         symbol = SYMBOL_HIGH;
-                    }
-
-                    if (channel->invert)
-                    {
-                        symbol = ~symbol & 0x7;
                     }
 
                     for (l = 2; l >= 0; l--)               // Symbol

--- a/ws2811.c
+++ b/ws2811.c
@@ -522,6 +522,11 @@ int ws2811_init(ws2811_t *ws2811)
         }
 
         memset(channel->leds, 0, sizeof(ws2811_led_t) * channel->count);
+
+        if (!channel->strip_type)
+        {
+          channel->strip_type=WS2811_STRIP_RGB;
+        }
     }
 
     device->dma_cb = (dma_cb_t *)device->mbox.virt_addr;
@@ -625,14 +630,17 @@ int ws2811_render(ws2811_t *ws2811)
         ws2811_channel_t *channel = &ws2811->channel[chan];
         int wordpos = chan;
         int scale   = (channel->brightness & 0xff) + 1;
+        int rshift  = (channel->strip_type >> 16) & 0xff;
+        int gshift  = (channel->strip_type >> 8)  & 0xff;
+        int bshift  = (channel->strip_type >> 0)  & 0xff;
 
         for (i = 0; i < channel->count; i++)                // Led
         {
             uint8_t color[] =
             {
-                (((channel->leds[i] >> 8)  & 0xff) * scale) >> 8, // green
-                (((channel->leds[i] >> 16) & 0xff) * scale) >> 8, // red
-                (((channel->leds[i] >> 0)  & 0xff) * scale) >> 8, // blue
+                (((channel->leds[i] >> gshift) & 0xff) * scale) >> 8, // green
+                (((channel->leds[i] >> rshift) & 0xff) * scale) >> 8, // red
+                (((channel->leds[i] >> bshift) & 0xff) * scale) >> 8, // blue
             };
 
             for (j = 0; j < ARRAY_SIZE(color); j++)        // Color

--- a/ws2811.c
+++ b/ws2811.c
@@ -489,13 +489,13 @@ int ws2811_init(ws2811_t *ws2811)
 
     device->mbox.mem_ref = mem_alloc(device->mbox.handle, device->mbox.size, PAGE_SIZE,
                                      rpi_hw->videocore_base == 0x40000000 ? 0xC : 0x4);
-    if (device->mbox.mem_ref < 0)
+    if (device->mbox.mem_ref == 0)
     {
        return -1;
     }
 
     device->mbox.bus_addr = mem_lock(device->mbox.handle, device->mbox.mem_ref);
-    if (device->mbox.bus_addr == ~0UL)
+    if (device->mbox.bus_addr == (uint32_t) ~0UL)
     {
        mem_free(device->mbox.handle, device->mbox.size);
        return -1;
@@ -617,7 +617,8 @@ int ws2811_render(ws2811_t *ws2811)
 {
     volatile uint8_t *pwm_raw = ws2811->device->pwm_raw;
     int bitpos = 31;
-    int i, j, k, l, chan;
+    int i, k, l, chan;
+    unsigned j;
 
     for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)         // Channel
     {

--- a/ws2811.c
+++ b/ws2811.c
@@ -390,7 +390,6 @@ void pwm_raw_init(ws2811_t *ws2811)
 
     for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)
     {
-        ws2811_channel_t *channel = &ws2811->channel[chan];
         int i, wordpos = chan;
 
         for (i = 0; i < wordcount; i++)

--- a/ws2811.h
+++ b/ws2811.h
@@ -40,6 +40,7 @@ extern "C" {
 
 
 #define WS2811_TARGET_FREQ                       800000   // Can go as low as 400000
+
 #define WS2811_STRIP_RGB                         0x100800
 #define WS2811_STRIP_RBG                         0x100008
 #define WS2811_STRIP_GRB                         0x081000

--- a/ws2811.h
+++ b/ws2811.h
@@ -31,6 +31,9 @@
 #ifndef __WS2811_H__
 #define __WS2811_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "rpihw.h"
 #include "pwm.h"
@@ -65,6 +68,9 @@ void ws2811_fini(ws2811_t *ws2811);              //< Tear it all down
 int ws2811_render(ws2811_t *ws2811);             //< Send LEDs off to hardware
 int ws2811_wait(ws2811_t *ws2811);               //< Wait for DMA completion
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __WS2811_H__ */
 

--- a/ws2811.h
+++ b/ws2811.h
@@ -40,6 +40,12 @@ extern "C" {
 
 
 #define WS2811_TARGET_FREQ                       800000   // Can go as low as 400000
+#define WS2811_STRIP_RGB                         0x100800
+#define WS2811_STRIP_RBG                         0x100008
+#define WS2811_STRIP_GRB                         0x081000
+#define WS2811_STRIP_GBR                         0x001008
+#define WS2811_STRIP_BRG                         0x080010
+#define WS2811_STRIP_BGR                         0x000810
 
 struct ws2811_device;
 
@@ -50,6 +56,7 @@ typedef struct
     int invert;                                  //< Invert output signal
     int count;                                   //< Number of LEDs, 0 if channel is unused
     int brightness;                              //< Brightness value between 0 and 255
+    int strip_type;                              //< Strip color layout -- one of WS2811_STRIP_xxx constants
     ws2811_led_t *leds;                          //< LED buffers, allocated by driver based on count
 } ws2811_channel_t;
 


### PR DESCRIPTION
The patches describe themselves.  I don't have an inverting level shifter so that patch is only marginally tested.  I added the new code before removing the old so I was doing a double-invert and I got the #33 "First Pixel Stuck Green" problem.  As submitted I think the patch should fix that problem as well.

Closes #17 -- tested and working.

All testing done on RPi 2, but I used the BCM2835 doc for the hardware change so it will be compatible with A+/B+ as well.