### PR TITLE
Fix crash on shutdown.

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -74,6 +74,7 @@ void *mapmem(unsigned base, unsigned size)
 
 void *unmapmem(void *addr, unsigned size)
 {
+   addr -= ((unsigned) addr) % PAGE_SIZE;
    int s = munmap(addr, size);
    if (s != 0) {
       printf("munmap error %d\n", s);


### PR DESCRIPTION
This fixes #48.  I don't know much about mmap/munmap, and the mmap code seems broken (in my lack of understanding).  It seems like we're requesting to map the actual address, but since it's not on a page boundary it drops back to the boundary, we map sizeof(struct); then access to the original location works anyway???  Is there something to mmap that I am missing?

This patch simply makes the munmap match mmap and fixes the crash.