### PR TITLE
Fix WS2811 Channel Output - Please see detailed explanation as WS2811 strip behavior may change

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -637,8 +637,8 @@ int ws2811_render(ws2811_t *ws2811)
         {
             uint8_t color[] =
             {
-                (((channel->leds[i] >> gshift) & 0xff) * scale) >> 8, // green
                 (((channel->leds[i] >> rshift) & 0xff) * scale) >> 8, // red
+                (((channel->leds[i] >> gshift) & 0xff) * scale) >> 8, // green
                 (((channel->leds[i] >> bshift) & 0xff) * scale) >> 8, // blue
             };
 

--- a/ws2811.h
+++ b/ws2811.h
@@ -44,8 +44,8 @@ extern "C" {
 #define WS2811_STRIP_RGB                         0x100800
 #define WS2811_STRIP_RBG                         0x100008
 #define WS2811_STRIP_GRB                         0x081000
-#define WS2811_STRIP_GBR                         0x001008
-#define WS2811_STRIP_BRG                         0x080010
+#define WS2811_STRIP_GBR                         0x080010
+#define WS2811_STRIP_BRG                         0x001008
 #define WS2811_STRIP_BGR                         0x000810
 
 struct ws2811_device;


### PR DESCRIPTION
This request fixes 2 WS2811 strip selection issues; the first fixes the channel order of the re-mapped output as it was still being written in the hardcoded output format for the original pixel type used by the author.  A detailed explanation is attached with this request.  The second fix relates to 2 WS2811 pixel type masks that were reversed.

[RPI_WS281X_Detailed_Explanation.pdf](https://github.com/jgarff/rpi_ws281x/files/150119/RPI_WS281X_Detailed_Explanation.pdf)

BE ADVISED - if other developers included a workaround in downstream software this update will impact the strip output and may require a different selection moving forward.

Tested on a known RGB WS2811 flood on Pi2 with master-1 FPP code.

Originally selecting an RGB order for a RPI_WS281X pixel (known to be in RGB order and works on other controllers as RGB) would display test sequence as GRB.  With the update the same scenario now displays as RGB, as well as fixes other error combinations.