### PR TITLE
Updates to work with Pi 3

### DIFF
--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
 	# Intialize the library (must be called once before other functions).
 	strip.begin()
 
-	print 'Press Ctrl-C to quit.'
+	print ('Press Ctrl-C to quit.')
 	while True:
 		# Color wipe animations.
 		colorWipe(strip, Color(255, 0, 0))  # Red wipe

--- a/rpihw.c
+++ b/rpihw.c
@@ -202,6 +202,18 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 2",
     },
+
+    //
+    // Pi 3 Model B
+    //
+    {
+        .hwver  = 0xa02082,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 3",
+    },
+
 };
 
 


### PR DESCRIPTION
Current version will not run on the Raspberry Pi 3 as the hardware revision number in cpuinfo is not recognised. 

This adds Raspberry Pi 3 to rpihw.c. It is defined using the same parameters as the Pi 2 as it is hardware compatible - other option would be to add #define entries for Pi3 which are duplicates of the Pi2 entries.

Also updated python strandtest.py to add brackets around the print arguments which allows it to install and work with Python 3 as well as Python 2.