### PR TITLE
Add aligned attribute to avoid issues with gcc5+ when accessing regis…

### DIFF
--- a/clk.h
+++ b/clk.h
@@ -51,7 +51,7 @@ typedef struct {
 #define CM_PWM_DIV_PASSWD                        (0x5a << 24)
 #define CM_PWM_DIV_DIVI(val)                     ((val & 0xfff) << 12)
 #define CM_PWM_DIV_DIVF(val)                     ((val & 0xfff) << 0)
-} __attribute__ ((packed)) cm_pwm_t;
+} __attribute__((packed, aligned(4))) cm_pwm_t;
 
 
 #define CM_PWM_OFFSET                            (0x001010a0)

--- a/dma.h
+++ b/dma.h
@@ -46,7 +46,7 @@ typedef struct
     uint32_t stride;
     uint32_t nextconbk;
     uint32_t resvd_0x18[2];
-} __attribute__((packed)) dma_cb_t;
+} __attribute__((packed, aligned(4))) dma_cb_t;
 
 /*
  * DMA register set
@@ -95,7 +95,7 @@ typedef struct
 #define RPI_DMA_STRIDE_S_STRIDE(val)             ((val & 0xffff) << 0)
     uint32_t nextconbk;
     uint32_t debug;
-} __attribute__((packed)) dma_t;
+} __attribute__((packed, aligned(4))) dma_t;
 
 
 #define DMA0_OFFSET                              (0x00007000)

--- a/gpio.h
+++ b/gpio.h
@@ -59,7 +59,7 @@ typedef struct
     uint32_t pudclk[2];                          // GPIO Pin Pull up/down Enable Clock
     uint32_t resvd_0xa0[4];
     uint32_t test;
-} __attribute__((packed)) gpio_t;
+} __attribute__((packed, aligned(4))) gpio_t;
 
 
 #define GPIO_OFFSET                              (0x00200000)

--- a/pwm.h
+++ b/pwm.h
@@ -96,7 +96,7 @@ typedef struct
     uint32_t resvd_0x1c;
     uint32_t rng2;
     uint32_t dat2;
-} __attribute__((packed)) pwm_t;
+} __attribute__((packed, aligned(4))) pwm_t;
 
 
 #define PWM_OFFSET                               (0x0020c000)


### PR DESCRIPTION
These changes aim to fix the register access issues with gcc 5.1+ initially reported in #39. Adding the aligned attribute makes gcc produce the desired code rather than assuming unaligned access. 

Please have a look if this is an acceptable solution.