### PR TITLE
Stop main loop after a signal to allow for clean shutdown

### DIFF
--- a/main.c
+++ b/main.c
@@ -83,6 +83,7 @@ ws2811_t ledstring =
 
 ws2811_led_t matrix[WIDTH][HEIGHT];
 
+static uint8_t running = 1;
 
 void matrix_render(void)
 {
@@ -141,7 +142,7 @@ void matrix_bottom(void)
 
 static void ctrl_c_handler(int signum)
 {
-    ws2811_fini(&ledstring);
+    running = 0;
 }
 
 static void setup_handlers(void)
@@ -166,7 +167,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    while (1)
+    while (running)
     {
         matrix_raise();
         matrix_bottom();


### PR DESCRIPTION
The current signal handling in the test example often causes segmentation faults after a signal was received. After the signal handler finished execution may continue at any point in the main loop including any functions called there. Thus it can occur that execution resumes just before an access to a pointer which was NULL'ed by the cleanup in the signal handler.

This patch fixes that by exiting the main loop after a signal and doing the cleanup afterwards.