### PR TITLE
Additional Model A+ Revision (hwver) 0x15

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -184,6 +184,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Model A+",
     },
+    {
+        .hwver  = 0x15,
+        .type = RPI_HWVER_TYPE_PI1,
+        .periph_base = PERIPH_BASE_RPI,
+        .videocore_base = VIDEOCORE_BASE_RPI,
+        .desc = "Model A+",
+    },
 
     //
     // Pi 2 Model B


### PR DESCRIPTION
Fix issue #79 by adding an additional block with the appropriate Revision (hwver) 0x15.