### PR TITLE
Support for hwver 0xa01040, Pi 2 pre-release & device-tree auto-detection

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -49,6 +49,15 @@
 #define RPI_MANUFACTURER_MASK                    (0xf << 16)
 #define RPI_WARRANTY_MASK                        (0x3 << 24)
 
+// Structure to store results of device-tree auto-detect
+static rpi_hw_t board_info = {
+    .hwver = 0x00,
+    .type = 0x00,
+    .periph_base = 0x00,
+    .videocore_base = 0x00,
+    .desc = "N/A"
+};
+
 static const rpi_hw_t rpi_hw_info[] = {
     //
     // Model B Rev 1.0
@@ -254,8 +263,54 @@ static const rpi_hw_t rpi_hw_info[] = {
 };
 
 
+static unsigned get_dt_ranges(const char *filename, unsigned offset)
+{
+    unsigned address = ~0;
+    FILE *fp = fopen(filename, "rb");
+    if (fp)
+    {
+        unsigned char buf[4];
+        fseek(fp, offset, SEEK_SET);
+        if (fread(buf, 1, sizeof buf, fp) == sizeof buf)
+        address = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
+        fclose(fp);
+    }
+    return address;
+}
+
+
+unsigned bcm_host_get_peripheral_address(void)
+{
+    return get_dt_ranges("/proc/device-tree/soc/ranges", 4);
+}
+
+
+unsigned bcm_host_get_peripheral_size(void)
+{
+    return get_dt_ranges("/proc/device-tree/soc/ranges", 8);
+}
+
+
+unsigned bcm_host_get_sdram_address(void)
+{
+    return get_dt_ranges("/proc/device-tree/axi/vc_mem/reg", 8);
+}
+
 const rpi_hw_t *rpi_hw_detect(void)
 {
+    // Attempt to auto-detect addresses from device-tree
+    unsigned videocore_base = bcm_host_get_sdram_address();
+    unsigned peripheral_base = bcm_host_get_peripheral_address();
+    
+    if(videocore_base != ~0 && peripheral_base != ~0){
+       
+        board_info.periph_base = peripheral_base;
+        board_info.videocore_base = videocore_base;
+        
+        return &board_info;
+    }
+
+    // Fall back to old method
     FILE *f = fopen("/proc/cpuinfo", "r");
     char line[LINE_WIDTH_MAX];
     const rpi_hw_t *result = NULL;

--- a/rpihw.c
+++ b/rpihw.c
@@ -180,6 +180,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Compute Module",
     },
+    {
+        .hwver  = 0x14,
+        .type = RPI_HWVER_TYPE_PI1,
+        .periph_base = PERIPH_BASE_RPI,
+        .videocore_base = VIDEOCORE_BASE_RPI,
+        .desc = "Compute Module",
+    },
 
     //
     // Pi Zero

--- a/rpihw.c
+++ b/rpihw.c
@@ -212,6 +212,13 @@ static const rpi_hw_t rpi_hw_info[] = {
     // Pi 2 Model B
     //
     {
+        .hwver  = 0xa01040,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 2",
+    },
+    {
         .hwver  = 0xa01041,
         .type = RPI_HWVER_TYPE_PI2,
         .periph_base = PERIPH_BASE_RPI2,


### PR DESCRIPTION
This PR includes:

* Support for hwver 0x14 - Compute Module
* Support for hwver 0xa01040 - Pre-release Raspberry Pi 2
* Attempt to get details from device-tree before falling back on hwver matching

## Included for posterity:

This PR adds support for a rare, pre-release Pi 2 edition. It also highlights the need for a more robust way of grabbing these offsets, with this method as the fallback. It can be done via the device-tree, at least half of the puzzle anyway.

For the peripheral offset RPi.GPIO uses:

```c
    if ((fp = fopen("/proc/device-tree/soc/ranges", "rb")) != NULL) {
        // get peri base from device tree
        fseek(fp, 4, SEEK_SET);
        if (fread(buf, 1, sizeof buf, fp) == sizeof buf) {
            peri_base = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
        }
        fclose(fp);
    } else {
```