### PR TITLE
Calculate color shift values only during init

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -532,6 +532,11 @@ int ws2811_init(ws2811_t *ws2811)
         {
           channel->strip_type=WS2811_STRIP_RGB;
         }
+
+        channel->wshift = (channel->strip_type >> 24) & 0xff;
+        channel->rshift = (channel->strip_type >> 16) & 0xff;
+        channel->gshift = (channel->strip_type >> 8)  & 0xff;
+        channel->bshift = (channel->strip_type >> 0)  & 0xff;
     }
 
     device->dma_cb = (dma_cb_t *)device->mbox.virt_addr;
@@ -634,20 +639,16 @@ int ws2811_render(ws2811_t *ws2811)
     {
         ws2811_channel_t *channel = &ws2811->channel[chan];
         int wordpos = chan;
-        int scale   = (channel->brightness & 0xff) + 1;
-        int wshift  = (channel->strip_type >> 24) & 0xff;
-        int rshift  = (channel->strip_type >> 16) & 0xff;
-        int gshift  = (channel->strip_type >> 8)  & 0xff;
-        int bshift  = (channel->strip_type >> 0)  & 0xff;
+        const int scale = channel->brightness + 1;
 
         for (i = 0; i < channel->count; i++)                // Led
         {
             uint8_t color[] =
             {
-                (((channel->leds[i] >> rshift) & 0xff) * scale) >> 8, // red
-                (((channel->leds[i] >> gshift) & 0xff) * scale) >> 8, // green
-                (((channel->leds[i] >> bshift) & 0xff) * scale) >> 8, // blue
-                (((channel->leds[i] >> wshift) & 0xff) * scale) >> 8, // white
+                (((channel->leds[i] >> channel->rshift) & 0xff) * scale) >> 8, // red
+                (((channel->leds[i] >> channel->gshift) & 0xff) * scale) >> 8, // green
+                (((channel->leds[i] >> channel->bshift) & 0xff) * scale) >> 8, // blue
+                (((channel->leds[i] >> channel->wshift) & 0xff) * scale) >> 8, // white
             };
             uint8_t array_size = 3; // Assume 3 color LEDs, RGB
 

--- a/ws2811.h
+++ b/ws2811.h
@@ -71,9 +71,13 @@ typedef struct
     int gpionum;                                 //< GPIO Pin with PWM alternate function, 0 if unused
     int invert;                                  //< Invert output signal
     int count;                                   //< Number of LEDs, 0 if channel is unused
-    int brightness;                              //< Brightness value between 0 and 255
     int strip_type;                              //< Strip color layout -- one of WS2811_STRIP_xxx constants
     ws2811_led_t *leds;                          //< LED buffers, allocated by driver based on count
+    uint8_t brightness;                          //< Brightness value between 0 and 255
+    uint8_t wshift;                              //< White shift value
+    uint8_t rshift;                              //< Red shift value
+    uint8_t gshift;                              //< Green shift value
+    uint8_t bshift;                              //< Blue shift value
 } ws2811_channel_t;
 
 typedef struct


### PR DESCRIPTION
This moves the color shift values into the `ws2811_channel_t` struct so that these values can be calculated during `ws2811_init` rather than being calculated again on every `ws2811_render` call. Efficiency should be improved a tiny bit by this.

It assumes that the strip type does not change anymore after `ws2811_init`. Not sure if it is considered a valid use case to change strip types on the fly, in that case this change could not be used.
