### PR TITLE
Fix typo for alternative pin

### DIFF
--- a/main.c
+++ b/main.c
@@ -245,7 +245,7 @@ void parseargs(int argc, char **argv, ws2811_t *ws2811)
 				"-x (--width)   - matrix width (default 8)\n"
 				"-y (--height)  - matrix height (default 8)\n"
 				"-d (--dma)     - dma channel to use (default 5)\n"
-				"-g (--gpio)    - GPIO to use must be one of 10,18,40,52\n"
+				"-g (--gpio)    - GPIO to use must be one of 12,18,40,52\n"
 				"                 If omitted, default is 18\n"
 				"-i (--invert)  - invert pin output (pulse LOW)\n"
 				"-c (--clear)   - clear matrix on exit.\n"
@@ -267,7 +267,7 @@ void parseargs(int argc, char **argv, ws2811_t *ws2811)
 	Only 13 is available on the B+/2B, on pin 35
 */
 				switch (gpio) {
-					case 10:
+					case 12:
 					case 18:
 					case 40:
 					case 52:


### PR DESCRIPTION
As the comment confirms 12 is an alternative to pin 18 and not 10.
