### PR TITLE
Add distinct error codes with string representations

### DIFF
--- a/main.c
+++ b/main.c
@@ -374,7 +374,7 @@ void parseargs(int argc, char **argv, ws2811_t *ws2811)
 
 int main(int argc, char *argv[])
 {
-    int ret = 0;
+    ws2811_return_t ret;
 
     parseargs(argc, argv, &ledstring);
 
@@ -382,9 +382,10 @@ int main(int argc, char *argv[])
 
     setup_handlers();
 
-    if (ws2811_init(&ledstring))
+    if ((ret = ws2811_init(&ledstring)) != WS2811_SUCCESS)
     {
-        return -1;
+        fprintf(stderr, "ws2811_init failed: %s\n", ws2811_get_return_t_str(ret));
+        return ret;
     }
 
     while (running)
@@ -393,9 +394,9 @@ int main(int argc, char *argv[])
         matrix_bottom();
         matrix_render();
 
-        if (ws2811_render(&ledstring))
+        if ((ret = ws2811_render(&ledstring)) != WS2811_SUCCESS)
         {
-            ret = -1;
+            fprintf(stderr, "ws2811_render failed: %s\n", ws2811_get_return_t_str(ret));
             break;
         }
 

--- a/python/examples/SK6812_lowlevel.py
+++ b/python/examples/SK6812_lowlevel.py
@@ -66,8 +66,9 @@ ws.ws2811_t_dmanum_set(leds, LED_DMA_NUM)
 
 # Initialize library with LED configuration.
 resp = ws.ws2811_init(leds)
-if resp != 0:
-	raise RuntimeError('ws2811_init failed with code {0}'.format(resp))
+if resp != ws.WS2811_SUCCESS:
+	message = ws.ws2811_get_return_t_str(resp)
+	raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
 
 # Wrap following code in a try/finally to ensure cleanup functions are called
 # after library is initialized.
@@ -84,8 +85,9 @@ try:
 
 		# Send the LED color data to the hardware.
 		resp = ws.ws2811_render(leds)
-		if resp != 0:
-			raise RuntimeError('ws2811_render failed with code {0}'.format(resp))
+		if resp != ws.WS2811_SUCCESS:
+			message = ws.ws2811_get_return_t_str(resp)
+			raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
 
 		# Delay for a small period of time.
 		time.sleep(0.25)

--- a/python/examples/lowlevel.py
+++ b/python/examples/lowlevel.py
@@ -60,8 +60,9 @@ ws.ws2811_t_dmanum_set(leds, LED_DMA_NUM)
 
 # Initialize library with LED configuration.
 resp = ws.ws2811_init(leds)
-if resp != 0:
-	raise RuntimeError('ws2811_init failed with code {0}'.format(resp))
+if resp != ws.WS2811_SUCCESS:
+	message = ws.ws2811_get_return_t_str(resp)
+	raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
 
 # Wrap following code in a try/finally to ensure cleanup functions are called
 # after library is initialized.
@@ -78,8 +79,9 @@ try:
 
 		# Send the LED color data to the hardware.
 		resp = ws.ws2811_render(leds)
-		if resp != 0:
-			raise RuntimeError('ws2811_render failed with code {0}'.format(resp))
+		if resp != ws.WS2811_SUCCESS:
+			message = ws.ws2811_get_return_t_str(resp)
+			raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
 
 		# Delay for a small period of time.
 		time.sleep(0.25)

--- a/python/neopixel.py
+++ b/python/neopixel.py
@@ -98,14 +98,16 @@ class Adafruit_NeoPixel(object):
 		called.
 		"""
 		resp = ws.ws2811_init(self._leds)
-		if resp != 0:
-			raise RuntimeError('ws2811_init failed with code {0}'.format(resp))
+		if resp != ws.WS2811_SUCCESS:
+			message = ws.ws2811_get_return_t_str(resp)
+			raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
 		
 	def show(self):
 		"""Update the display with the data from the LED buffer."""
 		resp = ws.ws2811_render(self._leds)
-		if resp != 0:
-			raise RuntimeError('ws2811_render failed with code {0}'.format(resp))
+		if resp != ws.WS2811_SUCCESS:
+			message = ws.ws2811_get_return_t_str(resp)
+			raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
 
 	def setPixelColor(self, n, color):
 		"""Set LED at position n to the provided 24-bit color value (in RGB order).

--- a/ws2811.c
+++ b/ws2811.c
@@ -453,7 +453,7 @@ void ws2811_cleanup(ws2811_t *ws2811)
  *
  * @returns  0 on success, -1 otherwise.
  */
-int ws2811_init(ws2811_t *ws2811)
+ws2811_return_t ws2811_init(ws2811_t *ws2811)
 {
     ws2811_device_t *device;
     const rpi_hw_t *rpi_hw;
@@ -462,14 +462,14 @@ int ws2811_init(ws2811_t *ws2811)
     ws2811->rpi_hw = rpi_hw_detect();
     if (!ws2811->rpi_hw)
     {
-        return -1;
+        return WS2811_ERROR_HW_NOT_SUPPORTED;
     }
     rpi_hw = ws2811->rpi_hw;
 
     ws2811->device = malloc(sizeof(*ws2811->device));
     if (!ws2811->device)
     {
-        return -1;
+        return WS2811_ERROR_OUT_OF_MEMORY;
     }
     device = ws2811->device;
 
@@ -482,21 +482,21 @@ int ws2811_init(ws2811_t *ws2811)
     device->mbox.handle = mbox_open();
     if (device->mbox.handle == -1)
     {
-        return -1;
+        return WS2811_ERROR_MAILBOX_DEVICE;
     }
 
     device->mbox.mem_ref = mem_alloc(device->mbox.handle, device->mbox.size, PAGE_SIZE,
                                      rpi_hw->videocore_base == 0x40000000 ? 0xC : 0x4);
     if (device->mbox.mem_ref == 0)
     {
-       return -1;
+        return WS2811_ERROR_OUT_OF_MEMORY;
     }
 
     device->mbox.bus_addr = mem_lock(device->mbox.handle, device->mbox.mem_ref);
     if (device->mbox.bus_addr == (uint32_t) ~0UL)
     {
-       mem_free(device->mbox.handle, device->mbox.size);
-       return -1;
+        mem_free(device->mbox.handle, device->mbox.size);
+        return WS2811_ERROR_MEM_LOCK;
     }
 
     device->mbox.virt_addr = mapmem(BUS_TO_PHYS(device->mbox.bus_addr), device->mbox.size);
@@ -504,7 +504,9 @@ int ws2811_init(ws2811_t *ws2811)
     {
         mem_unlock(device->mbox.handle, device->mbox.mem_ref);
         mem_free(device->mbox.handle, device->mbox.size);
-        goto err;
+
+        ws2811_cleanup(ws2811);
+        return WS2811_ERROR_MMAP;
     }
 
     // Initialize all pointers to NULL.  Any non-NULL pointers will be freed on cleanup.
@@ -523,7 +525,8 @@ int ws2811_init(ws2811_t *ws2811)
         channel->leds = malloc(sizeof(ws2811_led_t) * channel->count);
         if (!channel->leds)
         {
-            goto err;
+            ws2811_cleanup(ws2811);
+            return WS2811_ERROR_OUT_OF_MEMORY;
         }
 
         memset(channel->leds, 0, sizeof(ws2811_led_t) * channel->count);
@@ -547,29 +550,27 @@ int ws2811_init(ws2811_t *ws2811)
     // Map the physical registers into userspace
     if (map_registers(ws2811))
     {
-        goto err;
+        ws2811_cleanup(ws2811);
+        return WS2811_ERROR_MAP_REGISTERS;
     }
 
     // Initialize the GPIO pins
     if (gpio_init(ws2811))
     {
         unmap_registers(ws2811);
-        goto err;
+        ws2811_cleanup(ws2811);
+        return WS2811_ERROR_GPIO_INIT;
     }
 
     // Setup the PWM, clocks, and DMA
     if (setup_pwm(ws2811))
     {
         unmap_registers(ws2811);
-        goto err;
+        ws2811_cleanup(ws2811);
+        return WS2811_ERROR_PWM_SETUP;
     }
 
-    return 0;
-
-err:
-    ws2811_cleanup(ws2811);
-
-    return -1;
+    return WS2811_SUCCESS;
 }
 
 /**
@@ -596,7 +597,7 @@ void ws2811_fini(ws2811_t *ws2811)
  *
  * @returns  0 on success, -1 on DMA competion error
  */
-int ws2811_wait(ws2811_t *ws2811)
+ws2811_return_t ws2811_wait(ws2811_t *ws2811)
 {
     volatile dma_t *dma = ws2811->device->dma;
 
@@ -609,7 +610,7 @@ int ws2811_wait(ws2811_t *ws2811)
     if (dma->cs & RPI_DMA_CS_ERROR)
     {
         fprintf(stderr, "DMA Error: %08x\n", dma->debug);
-        return -1;
+        return WS2811_ERROR_DMA;
     }
 
     return 0;
@@ -623,12 +624,13 @@ int ws2811_wait(ws2811_t *ws2811)
  *
  * @returns  None
  */
-int ws2811_render(ws2811_t *ws2811)
+ws2811_return_t ws2811_render(ws2811_t *ws2811)
 {
     volatile uint8_t *pwm_raw = ws2811->device->pwm_raw;
     int bitpos = 31;
     int i, k, l, chan;
     unsigned j;
+    ws2811_return_t ret;
 
     for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)         // Channel
     {
@@ -694,9 +696,9 @@ int ws2811_render(ws2811_t *ws2811)
     }
 
     // Wait for any previous DMA operation to complete.
-    if (ws2811_wait(ws2811))
+    if ((ret = ws2811_wait(ws2811)) != WS2811_SUCCESS)
     {
-        return -1;
+        return ret;
     }
 
     dma_start(ws2811);
@@ -704,3 +706,15 @@ int ws2811_render(ws2811_t *ws2811)
     return 0;
 }
 
+const char * ws2811_get_return_t_str(const ws2811_return_t state)
+{
+    const int index = -state;
+    static const char * const ret_state_str[] = { WS2811_RETURN_STATES(WS2811_RETURN_STATES_STRING) };
+
+    if (index < sizeof(ret_state_str) / sizeof(ret_state_str[0]))
+    {
+        return ret_state_str[index];
+    }
+
+    return "";
+}

--- a/ws2811.h
+++ b/ws2811.h
@@ -85,11 +85,33 @@ typedef struct
     ws2811_channel_t channel[RPI_PWM_CHANNELS];
 } ws2811_t;
 
+#define WS2811_RETURN_STATES(X)                                                             \
+            X(0, WS2811_SUCCESS, "Success"),                                                \
+            X(-1, WS2811_ERROR_GENERIC, "Generic failure"),                                 \
+            X(-2, WS2811_ERROR_OUT_OF_MEMORY, "Out of memory"),                             \
+            X(-3, WS2811_ERROR_HW_NOT_SUPPORTED, "Hardware revision is not supported"),     \
+            X(-4, WS2811_ERROR_MEM_LOCK, "Memory lock failed"),                             \
+            X(-5, WS2811_ERROR_MMAP, "mmap() failed"),                                      \
+            X(-6, WS2811_ERROR_MAP_REGISTERS, "Unable to map registers into userspace"),    \
+            X(-7, WS2811_ERROR_GPIO_INIT, "Unable to initialize GPIO"),                     \
+            X(-8, WS2811_ERROR_PWM_SETUP, "Unable to initialize PWM"),                      \
+            X(-9, WS2811_ERROR_MAILBOX_DEVICE, "Failed to create mailbox device"),          \
+            X(-10, WS2811_ERROR_DMA, "DMA error")                                           \
 
-int ws2811_init(ws2811_t *ws2811);               //< Initialize buffers/hardware
-void ws2811_fini(ws2811_t *ws2811);              //< Tear it all down
-int ws2811_render(ws2811_t *ws2811);             //< Send LEDs off to hardware
-int ws2811_wait(ws2811_t *ws2811);               //< Wait for DMA completion
+#define WS2811_RETURN_STATES_ENUM(state, name, str) name = state
+#define WS2811_RETURN_STATES_STRING(state, name, str) str
+
+typedef enum {
+    WS2811_RETURN_STATES(WS2811_RETURN_STATES_ENUM),
+
+    WS2811_RETURN_STATE_COUNT
+} ws2811_return_t;
+
+ws2811_return_t ws2811_init(ws2811_t *ws2811);                         //< Initialize buffers/hardware
+void ws2811_fini(ws2811_t *ws2811);                                    //< Tear it all down
+ws2811_return_t ws2811_render(ws2811_t *ws2811);                       //< Send LEDs off to hardware
+ws2811_return_t ws2811_wait(ws2811_t *ws2811);                         //< Wait for DMA completion
+const char * ws2811_get_return_t_str(const ws2811_return_t state);     //< Get string representation of the given return state
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Heres my approach for adding distinct error codes for the function return states. The enum values are negative so existing code should work unchanged.

`ws2811_get_return_t_str` can be used to get the descriptive error strings (as done in the example). Maybe there a better suggestions for the function name though... :)
