### PR TITLE
Replaced __del__ with _cleanup to avoid assumptions about object state

### DIFF
--- a/python/neopixel.py
+++ b/python/neopixel.py
@@ -1,5 +1,7 @@
 # Adafruit NeoPixel library port to the rpi_ws281x library.
 # Author: Tony DiCola (tony@tonydicola.com), Jeremy Garff (jer@jers.net)
+import atexit
+
 import _rpi_ws281x as ws
 
 
@@ -83,8 +85,18 @@ class Adafruit_NeoPixel(object):
 
 		# Grab the led data array.
 		self._led_data = _LED_Data(self._channel, num)
+		
+		# Substitute for __del__, traps an exit condition and cleans up properly
+		atexit.register(self._cleanup)
 
 	def __del__(self):
+		# Required because Python will complain about memory leaks
+		# However there's no guarantee that "ws" will even be set 
+		# when the __del__ method for this class is reached.
+		if ws != None:
+			self._cleanup()
+			
+	def _cleanup(self):
 		# Clean up memory used by the library when not needed anymore.
 		if self._leds is not None:
 			ws.ws2811_fini(self._leds)


### PR DESCRIPTION
The existing use of `__del__` makes erroneous assumptions about the state of the `ws` object, which may or may not exist when it's called.

This causes calls to `ws_2811_fini` and `delete_ws2811_t` to fail, provoking a landslide of errors and memory leak warnings upon exit.

This fix add a new `_cleanup` routine that is triggered before objects are deleted, correctly cleaning up the state of ws2811.

Note: I also believe this library should be normalized to indentation of 4 spaces, as is conventional for Python, and not tabs. But that's something for another PR.
