### PR TITLE
Added new Raspberry Pi Zero revision: 920093

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -196,6 +196,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Pi Zero",
     },
+    {
+        .hwver  = 0x920093,
+        .type = RPI_HWVER_TYPE_PI1,
+        .periph_base = PERIPH_BASE_RPI,
+        .videocore_base = VIDEOCORE_BASE_RPI,
+        .desc = "Pi Zero v1.3",
+    },
 
     //
     // Model A+


### PR DESCRIPTION
The library is currently untested on this revision, but I believe it's just another variant of the v1.3 Pi Zero with a new quarter of manufacturer, or manufacturer. I'll confirm details ASAP and get the library tested.