### PR TITLE
Update rpihw.c

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -253,7 +253,16 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 2",
     },
-
+    //
+    // Pi 2 with BCM2837
+    //
+    {
+        .hwver  = 0xa22042,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 2",
+    },
     //
     // Pi 3 Model B
     //


### PR DESCRIPTION
Added details for new Pi 2 model with BCM2837 SOC.