### PR TITLE
Fixing Python README formatting

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,12 @@
 # Build
 
+```
   sudo apt-get install python-dev swig
   python ./setup.py build
+```
 
 # Run a demo
 
+```
   sudo PYTHONPATH=".:build/lib.linux-armv7l-2.7" python examples/strandtest.py
+```


### PR DESCRIPTION
The formatting for the commands to run for installing the python module didn't not render correctly, so I wrapped those lines in pre-format tags so that it would render as two separate lines instead of one.