### PR TITLE
Solve a TypeError regarding bitwise operations on a float

### DIFF
--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -59,7 +59,7 @@ def rainbowCycle(strip, wait_ms=20, iterations=5):
 	"""Draw rainbow that uniformly distributes itself across all pixels."""
 	for j in range(256*iterations):
 		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel(((i * 256 / strip.numPixels()) + j) & 255))
+			strip.setPixelColor(i, wheel((int(i * 256 / strip.numPixels()) + j) & 255))
 		strip.show()
 		time.sleep(wait_ms/1000.0)
 


### PR DESCRIPTION
When running this example on my Pi with python3 I got the following error:
```
Traceback (most recent call last):
  File "strandtest.py", line 97, in <module>
    rainbowCycle(strip)
  File "strandtest.py", line 62, in rainbowCycle
    strip.setPixelColor(i, wheel(((i * 256 / strip.numPixels()) + j) & 255))
TypeError: unsupported operand type(s) for &: 'float' and 'int'
```
Casting the result of the `i * 256 / strip.numPixels()) + j` operation to int allows the `&` bitwise operator to work later on.