### PR TITLE
Re added "Pi Zero W v1.1", .hwver = 0x9000c1,

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -217,6 +217,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Pi Zero W",
     },
+    {
+        .hwver  = 0x9000c1,
+        .type = RPI_HWVER_TYPE_PI1,
+        .periph_base = PERIPH_BASE_RPI,
+        .videocore_base = VIDEOCORE_BASE_RPI,
+        .desc = "Pi Zero W v1.1",
+    },
 
     //
     // Model A+


### PR DESCRIPTION
#158 has a merge conflict

here's a new PR which doesn't conflict