### PR TITLE
Add -lrt link flag for systems with older glibc

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -43,6 +43,7 @@ platforms = [
             'CPPPATH' : [
             ],
             'LINKFLAGS' : [
+                "-lrt",
             ],
         },
     ], 


### PR DESCRIPTION
This adds -lrt to the link flags to be able to link on systems with older glibc versions where -lrt is required for `clock_gettime`. For newer glibc versions it has no influence.

Closes #193.