### PR TITLE
Fix 32-bit overflow in get_microsecond_timestamp().

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -127,7 +127,7 @@ static uint64_t get_microsecond_timestamp()
         return 0;
     }
 
-    return t.tv_sec * 1000000 + t.tv_nsec / 1000;
+    return (uint64_t) t.tv_sec * 1000000 + t.tv_nsec / 1000;
 }
 
 /**


### PR DESCRIPTION
On Raspbian systems, the tv_sec member of struct timespec is 32 bits wide.  get_microsecond_timestamp() was overflowing in 32-bit arithmetic on this member.  This causes the time that it returns to jump ahead by many thousands of years at uptime = 35 minutes, 48 seconds.  (While the starting point for CLOCK_MONOTONIC_RAW is unspecified, it seems to track system uptime in practice.)

This didn't cause noticable problems for me--ws2811_render() skips the sleep when it thinks such a huge amount time has elapsed--but it could possibly result in rarely-occuring skipped frames if the WS2811 reset time isn't effectively honored by ws2811_render().