### PR TITLE
Bug fixes for Stretch and Compute Module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ PCM:
 ```
         PCM_DOUT, which can be set to use GPIOs 21 and 31.
         Only 21 is available on the B+/2B/PiZero/3B, on pin 40.
-        See also note for RPi 3 below.
 ```
 
 SPI:
 ```
         SPI0-MOSI is available on GPIOs 10 and 38.
         Only GPIO 10 is available on all models.
+        See also note for RPi 3 below.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ PCM:
 ```
         PCM_DOUT, which can be set to use GPIOs 21 and 31.
         Only 21 is available on the B+/2B/PiZero/3B, on pin 40.
+        See also note for RPi 3 below.
 ```
 
 SPI:
@@ -138,6 +139,12 @@ Many distributions have a maximum SPI transfer of 4096 bytes. This can be
 changed in /boot/cmdline.txt by appending
 ```
     spidev.bufsiz=32768
+```
+On a RPi 3 you have to change the GPU core frequency to 250 MHz, otherwise
+the SPI clock has the wrong frequency.
+Do this by adding the following line to /boot/config.txt and reboot.
+```
+    core_freq=250
 ```
 
 ### Comparison PWM/PCM/SPI

--- a/pcm.h
+++ b/pcm.h
@@ -127,7 +127,7 @@ typedef struct
 #define RPI_PCM_GRAY_FLUSH                      (1 << 2)
 #define RPI_PCM_GRAY_CLR                        (1 << 1)
 #define RPI_PCM_GRAY_EN                         (1 << 0)
-} __attribute__((packed)) pcm_t;
+} __attribute__((packed, aligned(4))) pcm_t;
 
 
 #define PCM_OFFSET                               (0x00203000)

--- a/pwm.c
+++ b/pwm.c
@@ -50,10 +50,6 @@ const pwm_pin_table_t pwm_pin_chan0[] =
         .pinnum = 40,
         .altnum = 0,
     },
-    {
-        .pinnum = 52,
-        .altnum = 1,
-    },
 };
 
 // Mapping of Pin to alternate function for PWM channel 1
@@ -74,10 +70,6 @@ const pwm_pin_table_t pwm_pin_chan1[] =
     {
         .pinnum = 45,
         .altnum = 0,
-    },
-    {
-        .pinnum = 53,
-        .altnum = 1,
     },
 };
 

--- a/rpihw.c
+++ b/rpihw.c
@@ -176,14 +176,14 @@ static const rpi_hw_t rpi_hw_info[] = {
         .type = RPI_HWVER_TYPE_PI1,
         .periph_base = PERIPH_BASE_RPI,
         .videocore_base = VIDEOCORE_BASE_RPI,
-        .desc = "Compute Module",
+        .desc = "Compute Module 1",
     },
     {
         .hwver  = 0x14,
         .type = RPI_HWVER_TYPE_PI1,
         .periph_base = PERIPH_BASE_RPI,
         .videocore_base = VIDEOCORE_BASE_RPI,
-        .desc = "Compute Module",
+        .desc = "Compute Module 1",
     },
 
     //
@@ -302,7 +302,7 @@ static const rpi_hw_t rpi_hw_info[] = {
         .type = RPI_HWVER_TYPE_PI2,
         .periph_base = PERIPH_BASE_RPI2,
         .videocore_base = VIDEOCORE_BASE_RPI2,
-        .desc = "Pi 3",
+        .desc = "Compute Module 3/L3",
     },
 
 };

--- a/ws2811.c
+++ b/ws2811.c
@@ -684,7 +684,7 @@ static int check_hwver_and_gpionum(ws2811_t *ws2811)
             }
         }
     }
-    else if (hwver >= 0x000e && hwver <= 0x000f)  // Models B Rev2, A
+    else if (hwver >= 0x0004 && hwver <= 0x000f)  // Models B Rev2, A
     {
         for ( i = 0; i < (int)(sizeof(gpionums_B2) / sizeof(gpionums_B2[0])); i++)
         {
@@ -694,7 +694,7 @@ static int check_hwver_and_gpionum(ws2811_t *ws2811)
             }
         }
     }
-    else if (hwver >= 0x010) // Models B+, A+, 2B, 3B
+    else if (hwver >= 0x010) // Models B+, A+, 2B, 3B, Zero Zero-W
     {
         if ((ws2811->channel[0].count == 0) && (ws2811->channel[1].count > 0))
         {

--- a/ws2811.c
+++ b/ws2811.c
@@ -729,6 +729,8 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     static uint8_t bits = 8;
     uint32_t speed = ws2811->freq * 3;
     ws2811_device_t *device = ws2811->device;
+    uint32_t base = ws2811->rpi_hw->periph_base;
+    int pinnum = ws2811->channel[0].gpionum;
 
     spi_fd = open("/dev/spidev0.0", O_RDWR);
     if (spi_fd < 0) {
@@ -775,9 +777,16 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     device->pcm = NULL;
     device->dma_cb = NULL;
     device->dma_cb_addr = 0;
-    device->gpio = NULL;
     device->cm_clk = NULL;
     device->mbox.handle = -1;
+
+    // Set SPI-MOSI pin
+    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t));
+    if (!device->gpio)
+    {
+        return WS2811_ERROR_SPI_SETUP;
+    }
+    gpio_function_set(device->gpio, pinnum, 0);	// SPI-MOSI ALT0
 
     // Allocate LED buffer
     ws2811_channel_t *channel = &ws2811->channel[0];


### PR DESCRIPTION
Missing aligned(4) attribute in pcm.h makes the PCM case failing under
Stretch, due to a newer version of gcc (6.x).
Also fixed a bug in check_hwver_and_gpionum, so original Model A is
recognised.