### PR TITLE
add missing memory allocation for SPI mode

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -806,6 +806,16 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     {
       channel->strip_type=WS2811_STRIP_RGB;
     }
+  
+    // Set default uncorrected gamma table
+    if (!channel->gamma)
+    {
+      channel->gamma = malloc(sizeof(uint8_t) * 256);
+      int x;
+      for(x = 0; x < 256; x++){
+        channel->gamma[x] = x;
+      }
+    }
 
     channel->wshift = (channel->strip_type >> 24) & 0xff;
     channel->rshift = (channel->strip_type >> 16) & 0xff;


### PR DESCRIPTION
This will fix the segmentation fault in SPI mode due to missing memory allocation for gamma.
#228 