### PR TITLE
Fix for segmentation fault on exit (Python)

### DIFF
--- a/python/neopixel.py
+++ b/python/neopixel.py
@@ -85,25 +85,16 @@ class Adafruit_NeoPixel(object):
 
 		# Grab the led data array.
 		self._led_data = _LED_Data(self._channel, num)
-		
+
 		# Substitute for __del__, traps an exit condition and cleans up properly
 		atexit.register(self._cleanup)
 
-	def __del__(self):
-		# Required because Python will complain about memory leaks
-		# However there's no guarantee that "ws" will even be set 
-		# when the __del__ method for this class is reached.
-		if ws != None:
-			self._cleanup()
-			
 	def _cleanup(self):
 		# Clean up memory used by the library when not needed anymore.
 		if self._leds is not None:
-			ws.ws2811_fini(self._leds)
 			ws.delete_ws2811_t(self._leds)
 			self._leds = None
 			self._channel = None
-			# Note that ws2811_fini will free the memory used by led_data internally.
 
 	def begin(self):
 		"""Initialize library, must be called once before other functions are
@@ -113,7 +104,7 @@ class Adafruit_NeoPixel(object):
 		if resp != ws.WS2811_SUCCESS:
 			message = ws.ws2811_get_return_t_str(resp)
 			raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
-		
+
 	def show(self):
 		"""Update the display with the data from the LED buffer."""
 		resp = ws.ws2811_render(self._leds)
@@ -140,7 +131,7 @@ class Adafruit_NeoPixel(object):
 		ws.ws2811_channel_t_brightness_set(self._channel, brightness)
 
 	def getPixels(self):
-		"""Return an object which allows access to the LED display data as if 
+		"""Return an object which allows access to the LED display data as if
 		it were a sequence of 24-bit RGB values.
 		"""
 		return self._led_data


### PR DESCRIPTION
NeoPixel Python examples, when quit with Ctrl+C, crash with a SEGFAULT on the Raspberry Pi 3 model B:

```
~/rpi_ws281x/python $ sudo python examples/strandtest.py
Press Ctrl-C to quit.
Color wipe animations.
^CTraceback (most recent call last):
  File "examples/strandtest.py", line 92, in <module>
    colorWipe(strip, Color(255, 0, 0))  # Red wipe
  File "examples/strandtest.py", line 30, in colorWipe
    time.sleep(wait_ms/1000.0)
KeyboardInterrupt
Segmentation fault
```

After some debugging I fixed the problem by removing the `ws.ws2811_fini(self._leds)` call from the `_cleanup()` method in the `Adafruit_NeoPixel` Python class.

I also removed the useless `__del__()` because `_cleanup()` already gets called by `atexit()`.
Now the Python samples do not SEGFAULT anymore.

This problem is not present with the compiled C samples.