### PR TITLE
Fix for non-root users & SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Do this by adding the following line to /boot/config.txt and reboot.
     core_freq=250
 ```
 
+SPI requires you to be in the `gpio` group if you wish to control your LEDs
+withou root.
+
 ### Comparison PWM/PCM/SPI
 
 Both PWM and PCM use DMA transfer to output the control signal for the LEDs.

--- a/mailbox.c
+++ b/mailbox.c
@@ -43,13 +43,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "mailbox.h"
 
 
-void *mapmem(uint32_t base, uint32_t size) {
+void *mapmem(uint32_t base, uint32_t size, const char *mem_dev) {
     uint32_t pagemask = ~0UL ^ (getpagesize() - 1);
     uint32_t offsetmask = getpagesize() - 1;
     int mem_fd;
     void *mem;
 
-    mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
+    mem_fd = open(mem_dev, O_RDWR | O_SYNC);
     if (mem_fd < 0) {
        perror("Can't open /dev/mem");
        return NULL;

--- a/mailbox.h
+++ b/mailbox.h
@@ -30,6 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MAJOR_NUM 100
 #define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
 
+#define DEV_MEM     "/dev/mem"
+#define DEV_GPIOMEM "/dev/gpiomem"
+
 int mbox_open(void);
 void mbox_close(int file_desc);
 

--- a/mailbox.h
+++ b/mailbox.h
@@ -38,7 +38,7 @@ unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
 unsigned mem_free(int file_desc, unsigned handle);
 unsigned mem_lock(int file_desc, unsigned handle);
 unsigned mem_unlock(int file_desc, unsigned handle);
-void *mapmem(unsigned base, unsigned size);
+void *mapmem(unsigned base, unsigned size, const char *mem_dev);
 void *unmapmem(void *addr, unsigned size);
 
 unsigned execute_code(int file_desc, unsigned code, unsigned r0, unsigned r1, unsigned r2, unsigned r3, unsigned r4, unsigned r5);

--- a/ws2811.c
+++ b/ws2811.c
@@ -175,7 +175,7 @@ static int map_registers(ws2811_t *ws2811)
     }
     dma_addr += rpi_hw->periph_base;
 
-    device->dma = mapmem(dma_addr, sizeof(dma_t), "/dev/mem");
+    device->dma = mapmem(dma_addr, sizeof(dma_t), DEV_MEM);
     if (!device->dma)
     {
         return -1;
@@ -183,7 +183,7 @@ static int map_registers(ws2811_t *ws2811)
 
     switch (device->driver_mode) {
     case PWM:
-        device->pwm = mapmem(PWM_OFFSET + base, sizeof(pwm_t), "/dev/mem");
+        device->pwm = mapmem(PWM_OFFSET + base, sizeof(pwm_t), DEV_MEM);
         if (!device->pwm)
         {
             return -1;
@@ -191,7 +191,7 @@ static int map_registers(ws2811_t *ws2811)
         break;
 
     case PCM:
-        device->pcm = mapmem(PCM_OFFSET + base, sizeof(pcm_t), "/dev/mem");
+        device->pcm = mapmem(PCM_OFFSET + base, sizeof(pcm_t), DEV_MEM);
         if (!device->pcm)
         {
             return -1;
@@ -204,7 +204,7 @@ static int map_registers(ws2811_t *ws2811)
      * However, it used /dev/mem before, so I'm leaving it as such.
      */
 
-    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), "/dev/mem");
+    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), DEV_MEM);
     if (!device->gpio)
     {
         return -1;
@@ -218,7 +218,7 @@ static int map_registers(ws2811_t *ws2811)
         offset = CM_PCM_OFFSET;
         break;
     }
-    device->cm_clk = mapmem(offset + base, sizeof(cm_clk_t), "/dev/mem");
+    device->cm_clk = mapmem(offset + base, sizeof(cm_clk_t), DEV_MEM);
     if (!device->cm_clk)
     {
         return -1;
@@ -791,7 +791,7 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     device->mbox.handle = -1;
 
     // Set SPI-MOSI pin
-    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), "/dev/gpiomem");
+    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), DEV_GPIOMEM);
     if (!device->gpio)
     {
         return WS2811_ERROR_SPI_SETUP;
@@ -940,7 +940,7 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
        return WS2811_ERROR_MEM_LOCK;
     }
 
-    device->mbox.virt_addr = mapmem(BUS_TO_PHYS(device->mbox.bus_addr), device->mbox.size, "/dev/mem");
+    device->mbox.virt_addr = mapmem(BUS_TO_PHYS(device->mbox.bus_addr), device->mbox.size, DEV_MEM);
     if (!device->mbox.virt_addr)
     {
         mem_unlock(device->mbox.handle, device->mbox.mem_ref);

--- a/ws2811.c
+++ b/ws2811.c
@@ -175,7 +175,7 @@ static int map_registers(ws2811_t *ws2811)
     }
     dma_addr += rpi_hw->periph_base;
 
-    device->dma = mapmem(dma_addr, sizeof(dma_t));
+    device->dma = mapmem(dma_addr, sizeof(dma_t), "/dev/mem");
     if (!device->dma)
     {
         return -1;
@@ -183,7 +183,7 @@ static int map_registers(ws2811_t *ws2811)
 
     switch (device->driver_mode) {
     case PWM:
-        device->pwm = mapmem(PWM_OFFSET + base, sizeof(pwm_t));
+        device->pwm = mapmem(PWM_OFFSET + base, sizeof(pwm_t), "/dev/mem");
         if (!device->pwm)
         {
             return -1;
@@ -191,7 +191,7 @@ static int map_registers(ws2811_t *ws2811)
         break;
 
     case PCM:
-        device->pcm = mapmem(PCM_OFFSET + base, sizeof(pcm_t));
+        device->pcm = mapmem(PCM_OFFSET + base, sizeof(pcm_t), "/dev/mem");
         if (!device->pcm)
         {
             return -1;
@@ -199,7 +199,12 @@ static int map_registers(ws2811_t *ws2811)
         break;
     }
 
-    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t));
+    /*
+     * The below call can potentially work with /dev/gpiomem instead.
+     * However, it used /dev/mem before, so I'm leaving it as such.
+     */
+
+    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), "/dev/mem");
     if (!device->gpio)
     {
         return -1;
@@ -213,7 +218,7 @@ static int map_registers(ws2811_t *ws2811)
         offset = CM_PCM_OFFSET;
         break;
     }
-    device->cm_clk = mapmem(offset + base, sizeof(cm_clk_t));
+    device->cm_clk = mapmem(offset + base, sizeof(cm_clk_t), "/dev/mem");
     if (!device->cm_clk)
     {
         return -1;
@@ -786,7 +791,7 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     device->mbox.handle = -1;
 
     // Set SPI-MOSI pin
-    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t));
+    device->gpio = mapmem(GPIO_OFFSET + base, sizeof(gpio_t), "/dev/gpiomem");
     if (!device->gpio)
     {
         return WS2811_ERROR_SPI_SETUP;
@@ -806,7 +811,7 @@ static ws2811_return_t spi_init(ws2811_t *ws2811)
     {
       channel->strip_type=WS2811_STRIP_RGB;
     }
-  
+
     // Set default uncorrected gamma table
     if (!channel->gamma)
     {
@@ -935,7 +940,7 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
        return WS2811_ERROR_MEM_LOCK;
     }
 
-    device->mbox.virt_addr = mapmem(BUS_TO_PHYS(device->mbox.bus_addr), device->mbox.size);
+    device->mbox.virt_addr = mapmem(BUS_TO_PHYS(device->mbox.bus_addr), device->mbox.size, "/dev/mem");
     if (!device->mbox.virt_addr)
     {
         mem_unlock(device->mbox.handle, device->mbox.mem_ref);


### PR DESCRIPTION
Non-root users can't access `/dev/mem`, but users in the `gpio` group can access `/dev/gpiomem`, which is all that's needed for SPI.
  
Existing functionality shouldn't be impacted, but this definitely does work on my machine with SPI now.