### PR TITLE
Fixed strandtest.py

### DIFF
--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -9,7 +9,6 @@ import time
 from neopixel import *
 from rpi_ws281x.rpi_ws281x import ws
 import argparse
-import sys
 
 # LED strip configuration:
 LED_COUNT      = 16      # Number of LED pixels.

--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # NeoPixel library strandtest example
 # Author: Tony DiCola (tony@tonydicola.com)
 #
@@ -11,15 +12,15 @@ import argparse
 import signal
 import sys
 def signal_handler(signal, frame):
-        colorWipe(strip, Color(0,0,0))
-        sys.exit(0)
+		colorWipe(strip, Color(0,0,0))
+		sys.exit(0)
 
 def opt_parse():
-        parser = argparse.ArgumentParser()
-        parser.add_argument('-c', action='store_true', help='clear the display on exit')
-        args = parser.parse_args()
-        if args.c:
-                signal.signal(signal.SIGINT, signal_handler)
+		parser = argparse.ArgumentParser()
+		parser.add_argument('-c', action='store_true', help='clear the display on exit')
+		args = parser.parse_args()
+		if args.c:
+				signal.signal(signal.SIGINT, signal_handler)
 
 # LED strip configuration:
 LED_COUNT      = 16      # Number of LED pixels.
@@ -30,7 +31,6 @@ LED_DMA        = 5       # DMA channel to use for generating signal (try 5)
 LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
 LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 LED_CHANNEL    = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
-LED_STRIP      = ws.WS2811_STRIP_GRB   # Strip type and colour ordering
 
 
 
@@ -93,25 +93,33 @@ def theaterChaseRainbow(strip, wait_ms=50):
 
 # Main program logic follows:
 if __name__ == '__main__':
-        # Process arguments
-        opt_parse()
+	# Process arguments
+	opt_parse()
 
 	# Create NeoPixel object with appropriate configuration.
-	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL, LED_STRIP)
+	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
 	# Intialize the library (must be called once before other functions).
 	strip.begin()
 
 	print ('Press Ctrl-C to quit.')
-	while True:
-		print ('Color wipe animations.')
-		colorWipe(strip, Color(255, 0, 0))  # Red wipe
-		colorWipe(strip, Color(0, 255, 0))  # Blue wipe
-		colorWipe(strip, Color(0, 0, 255))  # Green wipe
-		print ('Theater chase animations.')
-		theaterChase(strip, Color(127, 127, 127))  # White theater chase
-		theaterChase(strip, Color(127,   0,   0))  # Red theater chase
-		theaterChase(strip, Color(  0,   0, 127))  # Blue theater chase
-		print ('Rainbow animations.')
-		rainbow(strip)
-		rainbowCycle(strip)
-		theaterChaseRainbow(strip)
+
+	try:
+
+		while True:
+			print ('Color wipe animations.')
+			colorWipe(strip, Color(255, 0, 0))  # Red wipe
+			colorWipe(strip, Color(0, 255, 0))  # Blue wipe
+			colorWipe(strip, Color(0, 0, 255))  # Green wipe
+			print ('Theater chase animations.')
+			theaterChase(strip, Color(127, 127, 127))  # White theater chase
+			theaterChase(strip, Color(127,   0,   0))  # Red theater chase
+			theaterChase(strip, Color(  0,   0, 127))  # Blue theater chase
+			print ('Rainbow animations.')
+			rainbow(strip)
+			rainbowCycle(strip)
+			theaterChaseRainbow(strip)
+
+	except KeyboardInterrupt:
+		for j in range(strip.numPixels()):
+			strip.setPixelColor(j, Color(0,0,0))
+		exit(1)

--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -122,4 +122,5 @@ if __name__ == '__main__':
 	except KeyboardInterrupt:
 		for j in range(strip.numPixels()):
 			strip.setPixelColor(j, Color(0,0,0))
+			strip.show()
 		exit(1)

--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -122,5 +122,5 @@ if __name__ == '__main__':
 	except KeyboardInterrupt:
 		for j in range(strip.numPixels()):
 			strip.setPixelColor(j, Color(0,0,0))
-			strip.show()
+		strip.show()
 		exit(1)

--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -4,23 +4,12 @@
 #
 # Direct port of the Arduino NeoPixel library strandtest example.  Showcases
 # various animations on a strip of NeoPixels.
+
 import time
-
 from neopixel import *
-
+from rpi_ws281x.rpi_ws281x import ws
 import argparse
-import signal
 import sys
-def signal_handler(signal, frame):
-		colorWipe(strip, Color(0,0,0))
-		sys.exit(0)
-
-def opt_parse():
-		parser = argparse.ArgumentParser()
-		parser.add_argument('-c', action='store_true', help='clear the display on exit')
-		args = parser.parse_args()
-		if args.c:
-				signal.signal(signal.SIGINT, signal_handler)
 
 # LED strip configuration:
 LED_COUNT      = 16      # Number of LED pixels.
@@ -36,91 +25,93 @@ LED_CHANNEL    = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
 
 # Define functions which animate LEDs in various ways.
 def colorWipe(strip, color, wait_ms=50):
-	"""Wipe color across display a pixel at a time."""
-	for i in range(strip.numPixels()):
-		strip.setPixelColor(i, color)
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Wipe color across display a pixel at a time."""
+    for i in range(strip.numPixels()):
+        strip.setPixelColor(i, color)
+        strip.show()
+        time.sleep(wait_ms/1000.0)
 
 def theaterChase(strip, color, wait_ms=50, iterations=10):
-	"""Movie theater light style chaser animation."""
-	for j in range(iterations):
-		for q in range(3):
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, color)
-			strip.show()
-			time.sleep(wait_ms/1000.0)
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, 0)
+    """Movie theater light style chaser animation."""
+    for j in range(iterations):
+        for q in range(3):
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i+q, color)
+            strip.show()
+            time.sleep(wait_ms/1000.0)
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i+q, 0)
 
 def wheel(pos):
-	"""Generate rainbow colors across 0-255 positions."""
-	if pos < 85:
-		return Color(pos * 3, 255 - pos * 3, 0)
-	elif pos < 170:
-		pos -= 85
-		return Color(255 - pos * 3, 0, pos * 3)
-	else:
-		pos -= 170
-		return Color(0, pos * 3, 255 - pos * 3)
+    """Generate rainbow colors across 0-255 positions."""
+    if pos < 85:
+        return Color(pos * 3, 255 - pos * 3, 0)
+    elif pos < 170:
+        pos -= 85
+        return Color(255 - pos * 3, 0, pos * 3)
+    else:
+        pos -= 170
+        return Color(0, pos * 3, 255 - pos * 3)
 
 def rainbow(strip, wait_ms=20, iterations=1):
-	"""Draw rainbow that fades across all pixels at once."""
-	for j in range(256*iterations):
-		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel((i+j) & 255))
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Draw rainbow that fades across all pixels at once."""
+    for j in range(256*iterations):
+        for i in range(strip.numPixels()):
+            strip.setPixelColor(i, wheel((i+j) & 255))
+        strip.show()
+        time.sleep(wait_ms/1000.0)
 
 def rainbowCycle(strip, wait_ms=20, iterations=5):
-	"""Draw rainbow that uniformly distributes itself across all pixels."""
-	for j in range(256*iterations):
-		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel((int(i * 256 / strip.numPixels()) + j) & 255))
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Draw rainbow that uniformly distributes itself across all pixels."""
+    for j in range(256*iterations):
+        for i in range(strip.numPixels()):
+            strip.setPixelColor(i, wheel((int(i * 256 / strip.numPixels()) + j) & 255))
+        strip.show()
+        time.sleep(wait_ms/1000.0)
 
 def theaterChaseRainbow(strip, wait_ms=50):
-	"""Rainbow movie theater light style chaser animation."""
-	for j in range(256):
-		for q in range(3):
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, wheel((i+j) % 255))
-			strip.show()
-			time.sleep(wait_ms/1000.0)
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, 0)
+    """Rainbow movie theater light style chaser animation."""
+    for j in range(256):
+        for q in range(3):
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i+q, wheel((i+j) % 255))
+            strip.show()
+            time.sleep(wait_ms/1000.0)
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i+q, 0)
 
 # Main program logic follows:
 if __name__ == '__main__':
-	# Process arguments
-	opt_parse()
+    # Process arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--clear', action='store_true', help='clear the display on exit')
+    args = parser.parse_args()
 
-	# Create NeoPixel object with appropriate configuration.
-	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
-	# Intialize the library (must be called once before other functions).
-	strip.begin()
+    # Create NeoPixel object with appropriate configuration.
+    strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
+    # Intialize the library (must be called once before other functions).
+    strip.begin()
 
-	print ('Press Ctrl-C to quit.')
+    print ('Press Ctrl-C to quit.')
+    if not args.clear:
+        print('Use "-c" argument to clear LEDs on exit')
 
-	try:
+    try:
 
-		while True:
-			print ('Color wipe animations.')
-			colorWipe(strip, Color(255, 0, 0))  # Red wipe
-			colorWipe(strip, Color(0, 255, 0))  # Blue wipe
-			colorWipe(strip, Color(0, 0, 255))  # Green wipe
-			print ('Theater chase animations.')
-			theaterChase(strip, Color(127, 127, 127))  # White theater chase
-			theaterChase(strip, Color(127,   0,   0))  # Red theater chase
-			theaterChase(strip, Color(  0,   0, 127))  # Blue theater chase
-			print ('Rainbow animations.')
-			rainbow(strip)
-			rainbowCycle(strip)
-			theaterChaseRainbow(strip)
+        while True:
+            print ('Color wipe animations.')
+            colorWipe(strip, Color(255, 0, 0))  # Red wipe
+            colorWipe(strip, Color(0, 255, 0))  # Blue wipe
+            colorWipe(strip, Color(0, 0, 255))  # Green wipe
+            print ('Theater chase animations.')
+            theaterChase(strip, Color(127, 127, 127))  # White theater chase
+            theaterChase(strip, Color(127,   0,   0))  # Red theater chase
+            theaterChase(strip, Color(  0,   0, 127))  # Blue theater chase
+            print ('Rainbow animations.')
+            rainbow(strip)
+            rainbowCycle(strip)
+            theaterChaseRainbow(strip)
 
-	except KeyboardInterrupt:
-		for j in range(strip.numPixels()):
-			strip.setPixelColor(j, Color(0,0,0))
-		strip.show()
-		exit(1)
+    except KeyboardInterrupt:
+        if args.clear:
+            colorWipe(strip, Color(0,0,0), 10)


### PR DESCRIPTION
1. LEDs now turn off when CTRL+C is pressed.
2. Removed reference to ws.WS2811_STRIP_GRB, which was not imported and was causing the script to fail.  It is not needed for proper function.
3. Added shebang for our lovely Linux friends.
4. Fixed some indentation inconsistency.
  EDIT: strandtest.py was failing to run before these modifications