### PR TITLE
STRANDTEST: python example fix

### DIFF
--- a/python/examples/strandtest.py
+++ b/python/examples/strandtest.py
@@ -7,7 +7,7 @@
 
 import time
 from neopixel import *
-from rpi_ws281x.rpi_ws281x import ws
+import _rpi_ws281x as ws
 import argparse
 
 # LED strip configuration:


### PR DESCRIPTION
````
uname -a
Linux raspberrypi 4.9.59-v7+ #1047 SMP Sun Oct 29 12:19:23 GMT 2017 armv7l GNU/Linux

lsb_release -a
No LSB modules are available.
Distributor ID:	Raspbian
Description:	Raspbian GNU/Linux 9.3 (stretch)
Release:	9.3
Codename:	stretch

````

fixes the issue
````
sudo python examples/strandtest.pyTraceback (most recent call last):
  File "examples/strandtest.py", line 10, in <module>
    from rpi_ws281x.rpi_ws281x import ws
ImportError: No module named rpi_ws281x.rpi_ws281x
````