### PR TITLE
Add relative include and library paths to cgo.

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -7,9 +7,6 @@ Your path to the project should be:
 ```
 
 
-As listed in the `ws2811.go` file ensure to copy `ws2811.h`, `rpihw.h`, and `pwm.h` in a GCC include path (e.g. `/usr/local/include`) and
-`libws2811.a` in a GCC library path (e.g. `/usr/local/lib`).
-
 To run the basic example run the following commands:
 ```
   cd golang/examples

--- a/golang/ws2811/ws2811.go
+++ b/golang/ws2811/ws2811.go
@@ -24,17 +24,15 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*
-Interface to ws2811 chip (neopixel driver). Make sure that you have
-ws2811.h, rpihw.h, and pwm.h in a GCC include path (e.g. /usr/local/include) and
-libws2811.a in a GCC library path (e.g. /usr/local/lib).
+Interface to ws2811 chip (neopixel driver).
 See https://github.com/jgarff/rpi_ws281x for instructions
 */
 
 package ws2811
 
 /*
-#cgo CFLAGS: -std=c99
-#cgo LDFLAGS: -lws2811
+#cgo CFLAGS: -std=c99 -I../../
+#cgo LDFLAGS: -lws2811 -L../../
 #include "ws2811.go.h"
 */
 import "C"


### PR DESCRIPTION
Very minor change which avoids the need to copy the .h/.a files in order to make them available for building.
One can `go build` projects importing rwi_ws281x/golang/ws2811 right away (after runnings scons to create the library, of course)