### PR TITLE
Fix Crash in rainbowCycle

### DIFF
--- a/python/examples/SK6812_strandtest.py
+++ b/python/examples/SK6812_strandtest.py
@@ -62,7 +62,7 @@ def rainbowCycle(strip, wait_ms=20, iterations=5):
 	"""Draw rainbow that uniformly distributes itself across all pixels."""
 	for j in range(256*iterations):
 		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel(((i * 256 / strip.numPixels()) + j) & 255))
+			strip.setPixelColor(i, wheel(((i * 256 // strip.numPixels()) + j) & 255))
 		strip.show()
 		time.sleep(wait_ms/1000.0)
 


### PR DESCRIPTION
When running this script, I was getting a TypeError: unsupported operand type(s) for &: 'float' and 'int'
on line 64. `//` returns int instead of float like `/` does, which fixes this issue.