### PR TITLE
Deprecation warnings for legacy Go and Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Preliminary support is now included for SK6812RGBW LEDs (yes, RGB + W)
 The LEDs can be controlled by either the PWM (2 independent channels)
 or PCM controller (1 channel) or the SPI interface (1 channel).
 
+### Bindings:
+
+Language-specific bindings for rpi_ws281x are available in:
+
+* Python - https://github.com/rpi-ws281x/rpi-ws281x-python
+* Rust - https://github.com/rpi-ws281x/rpi-ws281x-rust
+* Powershell - https://github.com/rpi-ws281x/rpi-ws281x-powershell
+* Java - https://github.com/rpi-ws281x/rpi-ws281x-java
+* CSharp - https://github.com/rpi-ws281x/rpi-ws281x-csharp
+* Go - https://github.com/rpi-ws281x/rpi-ws281x-go
+
 ### Background:
 
 The BCM2835 in the Raspberry Pi has both a PWM and a PCM module that

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,3 +1,13 @@
+## Deprecated
+
+This Go code is being phased out and replaced with https://github.com/rpi-ws281x/rpi-ws281x-go
+
+For issues and bugs with (or contributions to) the Go library, please see: https://github.com/rpi-ws281x/rpi-ws281x-go/issues
+
+----
+
+
+
 ## Run a demo
 
 As this is just a Go wrapper for the library you must clone this into your `$GOPATH` as you would any other Go program. 

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,14 @@
+## Deprecated
+
+This Python code is being phased out and replaced with https://github.com/rpi-ws281x/rpi-ws281x-python
+
+If you're just looking to install the Python library, you can: `sudo pip install rpi_ws281x` or `sudo pip3 install rpi_ws281x` depending on your Python version of choice or find releases here: https://github.com/rpi-ws281x/rpi-ws281x-python/releases
+
+For issues and bugs with (or contributions to) the Python library, please see: https://github.com/rpi-ws281x/rpi-ws281x-python/issues
+
+----
+
+
 ## Build
 
 As this is just a python wrapper for the library you must first follow

--- a/rpihw.c
+++ b/rpihw.c
@@ -212,13 +212,6 @@ static const rpi_hw_t rpi_hw_info[] = {
         .desc = "Pi Zero v1.3",
     },
     {
-        .hwver  = 0x9200c1,
-        .type = RPI_HWVER_TYPE_PI1,
-        .periph_base = PERIPH_BASE_RPI,
-        .videocore_base = VIDEOCORE_BASE_RPI,
-        .desc = "Pi Zero W v1.1",
-    },
-    {
         .hwver  = 0x9000c1,
         .type = RPI_HWVER_TYPE_PI1,
         .periph_base = PERIPH_BASE_RPI,

--- a/rpihw.c
+++ b/rpihw.c
@@ -251,6 +251,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Model A+",
     },
+    {
+        .hwver  = 0x9020e0,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Model 3 A+",
+    },
 
     //
     // Pi 2 Model B

--- a/rpihw.c
+++ b/rpihw.c
@@ -323,55 +323,6 @@ static const rpi_hw_t rpi_hw_info[] = {
 
 };
 
-static unsigned get_dt_ranges(const char *filename, unsigned offset)
-{
-    unsigned address = ~0;
-    FILE *fp = fopen(filename, "rb");
-    if (fp)
-    {
-        unsigned char buf[4];
-        fseek(fp, offset, SEEK_SET);
-        if (fread(buf, 1, sizeof buf, fp) == sizeof buf)
-        address = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
-        fclose(fp);
-    }
-    return address;
-}
-
-unsigned bcm_host_get_peripheral_address(void)
-{
-    return get_dt_ranges("/proc/device-tree/soc/ranges", 4);
-}
-
-unsigned bcm_host_get_peripheral_size(void)
-{
-    return get_dt_ranges("/proc/device-tree/soc/ranges", 8);
-}
-
-unsigned bcm_host_get_sdram_address(void)
-{
-    return get_dt_ranges("/proc/device-tree/axi/vc_mem/reg", 8);
-}
-
-const rpi_hw_t *rpi_dt_hw_detect(void){
-    // Attempt to auto-detect addresses from device-tree
-    unsigned videocore_base = bcm_host_get_sdram_address();
-    unsigned peripheral_base = bcm_host_get_peripheral_address();
-
-    if(videocore_base != ~0 && peripheral_base != ~0){
-
-        board_info.periph_base = peripheral_base;
-        board_info.videocore_base = videocore_base;
-        return &board_info;
-
-    }
-    else
-    {
-        // Fail over to classic detection
-        return rpi_hw_detect();
-    }
-}
-
 const rpi_hw_t *rpi_hw_detect(void)
 {
     const rpi_hw_t *result = NULL;

--- a/rpihw.c
+++ b/rpihw.c
@@ -50,6 +50,15 @@
 #define RPI_MANUFACTURER_MASK                    (0xf << 16)
 #define RPI_WARRANTY_MASK                        (0x3 << 24)
 
+// Structure to store results of device-tree auto-detect
+static rpi_hw_t board_info = {
+    .hwver = 0x00,
+    .type = 0x00,
+    .periph_base = 0x00,
+    .videocore_base = 0x00,
+    .desc = "N/A"
+};
+
 static const rpi_hw_t rpi_hw_info[] = {
     //
     // Model B Rev 1.0
@@ -315,6 +324,51 @@ static const rpi_hw_t rpi_hw_info[] = {
 
 };
 
+static unsigned get_dt_ranges(const char *filename, unsigned offset)
+{
+    unsigned address = ~0;
+    FILE *fp = fopen(filename, "rb");
+    if (fp)
+    {
+        unsigned char buf[4];
+        fseek(fp, offset, SEEK_SET);
+        if (fread(buf, 1, sizeof buf, fp) == sizeof buf)
+        address = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
+        fclose(fp);
+    }
+    return address;
+}
+
+unsigned bcm_host_get_peripheral_address(void)
+{
+    return get_dt_ranges("/proc/device-tree/soc/ranges", 4);
+}
+
+unsigned bcm_host_get_peripheral_size(void)
+{
+    return get_dt_ranges("/proc/device-tree/soc/ranges", 8);
+}
+
+unsigned bcm_host_get_sdram_address(void)
+{
+    return get_dt_ranges("/proc/device-tree/axi/vc_mem/reg", 8);
+}
+
+const rpi_hw_t *rpi_dt_hw_detect(void){
+    // Attempt to auto-detect addresses from device-tree
+    unsigned videocore_base = bcm_host_get_sdram_address();
+    unsigned peripheral_base = bcm_host_get_peripheral_address();
+
+    if(videocore_base != ~0 && peripheral_base != ~0){
+
+        board_info.periph_base = peripheral_base;
+        board_info.videocore_base = videocore_base;
+        return &board_info;
+
+    }
+
+    return NULL;
+}
 
 const rpi_hw_t *rpi_hw_detect(void)
 {

--- a/rpihw.c
+++ b/rpihw.c
@@ -218,6 +218,14 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Pi Zero W v1.1",
     },
+    {
+        .hwver  = 0x9200c1,
+        .type = RPI_HWVER_TYPE_PI1,
+        .periph_base = PERIPH_BASE_RPI,
+        .videocore_base = VIDEOCORE_BASE_RPI,
+        .desc = "Pi Zero W v1.1",
+    },
+
 
     //
     // Model A+
@@ -357,8 +365,11 @@ const rpi_hw_t *rpi_dt_hw_detect(void){
         return &board_info;
 
     }
-
-    return NULL;
+    else
+    {
+        // Fail over to classic detection
+        return rpi_hw_detect();
+    }
 }
 
 const rpi_hw_t *rpi_hw_detect(void)

--- a/rpihw.c
+++ b/rpihw.c
@@ -50,15 +50,6 @@
 #define RPI_MANUFACTURER_MASK                    (0xf << 16)
 #define RPI_WARRANTY_MASK                        (0x3 << 24)
 
-// Structure to store results of device-tree auto-detect
-static rpi_hw_t board_info = {
-    .hwver = 0x00,
-    .type = 0x00,
-    .periph_base = 0x00,
-    .videocore_base = 0x00,
-    .desc = "N/A"
-};
-
 static const rpi_hw_t rpi_hw_info[] = {
     //
     // Model B Rev 1.0

--- a/rpihw.h
+++ b/rpihw.h
@@ -45,6 +45,7 @@ typedef struct {
 
 
 const rpi_hw_t *rpi_hw_detect(void);
+const rpi_hw_t *rpi_dt_hw_detect(void);
 
 
 #endif /* __RPIHW_H__ */

--- a/rpihw.h
+++ b/rpihw.h
@@ -45,7 +45,5 @@ typedef struct {
 
 
 const rpi_hw_t *rpi_hw_detect(void);
-const rpi_hw_t *rpi_dt_hw_detect(void);
-
 
 #endif /* __RPIHW_H__ */

--- a/ws2811.c
+++ b/ws2811.c
@@ -880,7 +880,7 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     const rpi_hw_t *rpi_hw;
     int chan;
 
-    ws2811->rpi_hw = rpi_hw_detect();
+    ws2811->rpi_hw = rpi_dt_hw_detect();
     if (!ws2811->rpi_hw)
     {
         return WS2811_ERROR_HW_NOT_SUPPORTED;

--- a/ws2811.c
+++ b/ws2811.c
@@ -945,7 +945,7 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     const rpi_hw_t *rpi_hw;
     int chan;
 
-    ws2811->rpi_hw = rpi_dt_hw_detect();
+    ws2811->rpi_hw = rpi_hw_detect();
     if (!ws2811->rpi_hw)
     {
         return WS2811_ERROR_HW_NOT_SUPPORTED;

--- a/ws2811.c
+++ b/ws2811.c
@@ -1027,7 +1027,7 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     // Allocate the LED buffers
     for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)
     {
-	ws2811_channel_t *channel = &ws2811->channel[chan];
+        ws2811_channel_t *channel = &ws2811->channel[chan];
 
         channel->leds = malloc(sizeof(ws2811_led_t) * channel->count);
         if (!channel->leds)

--- a/ws2811.c
+++ b/ws2811.c
@@ -1027,13 +1027,13 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     // Allocate the LED buffers
     for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)
     {
-        ws2811_channel_t *channel = &ws2811->channel[chan];
+	ws2811_channel_t *channel = &ws2811->channel[chan];
 
         channel->leds = malloc(sizeof(ws2811_led_t) * channel->count);
         if (!channel->leds)
         {
             ws2811_cleanup(ws2811);
-	    return WS2811_ERROR_OUT_OF_MEMORY;
+            return WS2811_ERROR_OUT_OF_MEMORY;
         }
 
         memset(channel->leds, 0, sizeof(ws2811_led_t) * channel->count);


### PR DESCRIPTION
The following commit includes deprecation warnings added into the top of the README.md files for the Go and Python bindings in this repository.

They have been superseded by: https://github.com/rpi-ws281x/rpi-ws281x-go and https://github.com/rpi-ws281x/rpi-ws281x-python respectively.

Edit: Oh boy is this ever messy with commit history!

Edit: Note, I didn't want to be *too* harsh with this PR, but I believe the correct course of action would be to completely remove the deprecated files from this repository. They'll live on in the GitHub history for posterity, but right now they just cause confusion and not everyone reads warnings.