### PR TITLE
Fix python build by update curl command line to follow redirects

### DIFF
--- a/python/ez_setup.py
+++ b/python/ez_setup.py
@@ -205,7 +205,7 @@ def has_powershell():
 download_file_powershell.viable = has_powershell
 
 def download_file_curl(url, target):
-    cmd = ['curl', url, '--silent', '--output', target]
+    cmd = ['curl', '-L', url, '--silent', '--output', target]
     _clean_check(cmd, target)
 
 def has_curl():


### PR DESCRIPTION
As part of default build process (`python ./setup.py build`) this file `https://pypi.python.org/packages/source/s/setuptools/setuptools-5.7.zip` is downloaded.
But it looks like recently server configuration has changed and above URL is redirecting to different one (like [this](https://files.pythonhosted.org/packages/08/1b/cfcdd4381459c3967a08dd3b7c16b7f10a5bfb8ad5c40b56f8ee4a25e8d7/setuptools-5.7.zip) for me).
But `curl` used as one of methods to download this file, by default do not follow `HTTP 302` redirects, so there is error during build process. Adding `-L` param fixes this problem.

It looks like other methods to download file (PowerShell and wget) are working fine with this redirect.