### PR TITLE
Add deprecation warnings for legacy bindings and links to ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Preliminary support is now included for SK6812RGBW LEDs (yes, RGB + W)
 The LEDs can be controlled by either the PWM (2 independent channels)
 or PCM controller (1 channel) or the SPI interface (1 channel).
 
+### Bindings:
+
+Language-specific bindings for rpi_ws281x are available in:
+
+* Python - https://github.com/rpi-ws281x/rpi-ws281x-python
+* Rust - https://github.com/rpi-ws281x/rpi-ws281x-rust
+* Powershell - https://github.com/rpi-ws281x/rpi-ws281x-powershell
+* Java - https://github.com/rpi-ws281x/rpi-ws281x-java
+* CSharp - https://github.com/rpi-ws281x/rpi-ws281x-csharp
+* Go - https://github.com/rpi-ws281x/rpi-ws281x-go
+
 ### Background:
 
 The BCM2835 in the Raspberry Pi has both a PWM and a PCM module that

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,3 +1,11 @@
+## Deprecated
+
+This Go code is being phased out and replaced with https://github.com/rpi-ws281x/rpi-ws281x-go
+
+For issues and bugs with (or contributions to) the Go library, please see: https://github.com/rpi-ws281x/rpi-ws281x-go/issues
+
+----
+
 ## Run a demo
 
 As this is just a Go wrapper for the library you must clone this into your `$GOPATH` as you would any other Go program. 

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,13 @@
+## Deprecated
+
+This Python code is being phased out and replaced with https://github.com/rpi-ws281x/rpi-ws281x-python
+
+If you're just looking to install the Python library, you can: `sudo pip install rpi_ws281x` or `sudo pip3 install rpi_ws281x` depending on your Python version of choice or find releases here: https://github.com/rpi-ws281x/rpi-ws281x-python/releases
+
+For issues and bugs with (or contributions to) the Python library, please see: https://github.com/rpi-ws281x/rpi-ws281x-python/issues
+
+----
+
 ## Build
 
 As this is just a python wrapper for the library you must first follow


### PR DESCRIPTION
This is a take 2 of  #317 -

The following commit includes deprecation warnings added into the top of the README.md files for the Go and Python bindings in this repository.

They have been superseded by: https://github.com/rpi-ws281x/rpi-ws281x-go and https://github.com/rpi-ws281x/rpi-ws281x-python respectively.