### PR TITLE
Update rpihw.c

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -250,6 +250,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI,
         .desc = "Model A+",
     },
+    {
+        .hwver  = 0x9020e0,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 3 Model A+",
+    },
 
     //
     // Pi 2 Model B


### PR DESCRIPTION
Adding support for Raspberry Pi 3 Model A+:
    {
        .hwver  = 0x9020e0,
        .type = RPI_HWVER_TYPE_PI2,
        .periph_base = PERIPH_BASE_RPI2,
        .videocore_base = VIDEOCORE_BASE_RPI2,
        .desc = "Pi 3 Model A+",
    },