### PR TITLE
Fix extra semicolon in pcm.h

### DIFF
--- a/pcm.h
+++ b/pcm.h
@@ -75,7 +75,7 @@ typedef struct
 #define RPI_PCM_CS_RXON                         (1 << 1)
 #define RPI_PCM_CS_EN                           (1 << 0)
     uint32_t fifo;
-    uint32_t mode;;
+    uint32_t mode;
 #define RPI_PCM_MODE_CLK_DIS                    (1 << 28)
 #define RPI_PCM_MODE_PDMN                       (1 << 27)
 #define RPI_PCM_MODE_PDME                       (1 << 26)


### PR DESCRIPTION
There was an extra semicolon in `pcm.h`, which resulted in a warning using `-Wpedantic`. This PR fixes this warning.

```
rpi_ws281x/pcm.h:78:19: warning: extra semicolon in struct or union specified [-Wpedantic]
     uint32_t mode;;
                   ^
```