### PR TITLE
Add a22083 	3B 	1.3 	1 GB 	Embest hardware code [raspberry pi]

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -310,6 +310,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .desc = "Pi 3",
     },
     {
+        .hwver  = 0xa22083,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 3",
+    },
+    {
         .hwver  = 0x9020e0,
         .type = RPI_HWVER_TYPE_PI2,
         .periph_base = PERIPH_BASE_RPI2,


### PR DESCRIPTION
A not so common raspberry pi 3b made by Embest manufacturer  has code 'a22083'.