### PR TITLE
Support for Raspberry Pi 4

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -68,7 +68,7 @@ void *mapmem(uint32_t base, uint32_t size, const char *mem_dev) {
 
 void *unmapmem(void *addr, uint32_t size) {
     uint32_t pagemask = ~0UL ^ (getpagesize() - 1);
-    uint32_t baseaddr = (uint32_t)addr & pagemask;
+    uintptr_t baseaddr = (uintptr_t)addr & pagemask;
     int s;
     
     s = munmap((void *)baseaddr, size);

--- a/rpihw.c
+++ b/rpihw.c
@@ -43,6 +43,7 @@
 
 #define PERIPH_BASE_RPI                          0x20000000
 #define PERIPH_BASE_RPI2                         0x3f000000
+#define PERIPH_BASE_RPI4                         0xfe000000
 
 #define VIDEOCORE_BASE_RPI                       0x40000000
 #define VIDEOCORE_BASE_RPI2                      0xc0000000
@@ -51,6 +52,13 @@
 #define RPI_WARRANTY_MASK                        (0x3 << 24)
 
 static const rpi_hw_t rpi_hw_info[] = {
+    {
+        .hwver = 0xC03111,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4"
+    },
     //
     // Model B Rev 1.0
     //

--- a/rpihw.c
+++ b/rpihw.c
@@ -52,12 +52,29 @@
 #define RPI_WARRANTY_MASK                        (0x3 << 24)
 
 static const rpi_hw_t rpi_hw_info[] = {
+    //
+    // Raspberry Pi 4
+    //
+    {
+        .hwver = 0xA03111,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 1GB"
+    },
+    {
+        .hwver = 0xB03111,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 2GB"
+    },
     {
         .hwver = 0xC03111,
         .type = RPI_HWVER_TYPE_PI4,
         .periph_base = PERIPH_BASE_RPI4,
         .videocore_base = VIDEOCORE_BASE_RPI2,
-        .desc = "Pi 4"
+        .desc = "Pi 4 Model B - 4GB"
     },
     //
     // Model B Rev 1.0

--- a/rpihw.h
+++ b/rpihw.h
@@ -37,6 +37,7 @@ typedef struct {
 #define RPI_HWVER_TYPE_UNKNOWN                   0
 #define RPI_HWVER_TYPE_PI1                       1
 #define RPI_HWVER_TYPE_PI2                       2
+#define RPI_HWVER_TYPE_PI4                       3
     uint32_t hwver;
     uint32_t periph_base;
     uint32_t videocore_base;

--- a/ws2811.c
+++ b/ws2811.c
@@ -392,7 +392,7 @@ static int setup_pwm(ws2811_t *ws2811)
 
     dma_cb->source_ad = addr_to_bus(device, device->pxl_raw);
 
-    dma_cb->dest_ad = (uint32_t)&((pwm_t *)PWM_PERIPH_PHYS)->fif1;
+    dma_cb->dest_ad = (uintptr_t)&((pwm_t *)PWM_PERIPH_PHYS)->fif1;
     dma_cb->txfr_len = byte_count;
     dma_cb->stride = 0;
     dma_cb->nextconbk = 0;
@@ -457,7 +457,7 @@ static int setup_pcm(ws2811_t *ws2811)
                  RPI_DMA_TI_SRC_INC;          // Increment src addr
 
     dma_cb->source_ad = addr_to_bus(device, device->pxl_raw);
-    dma_cb->dest_ad = (uint32_t)&((pcm_t *)PCM_PERIPH_PHYS)->fifo;
+    dma_cb->dest_ad = (uintptr_t)&((pcm_t *)PCM_PERIPH_PHYS)->fifo;
     dma_cb->txfr_len = byte_count;
     dma_cb->stride = 0;
     dma_cb->nextconbk = 0;

--- a/ws2811.c
+++ b/ws2811.c
@@ -56,6 +56,7 @@
 #define BUS_TO_PHYS(x)                           ((x)&~0xC0000000)
 
 #define OSC_FREQ                                 19200000   // crystal frequency
+#define OSC_FREQ_PI4                             (OSC_FREQ * 2)
 
 /* 4 colors (R, G, B + W), 8 bits per byte, 3 symbols per bit + 55uS low for reset signal */
 #define LED_COLOURS                              4
@@ -347,10 +348,18 @@ static int setup_pwm(ws2811_t *ws2811)
     uint32_t freq = ws2811->freq;
     int32_t byte_count;
 
+    const rpi_hw_t *rpi_hw = ws2811->rpi_hw;
+    const uint32_t rpi_type = rpi_hw->type;
+    uint32_t osc_freq = OSC_FREQ;
+
+    if(rpi_type == RPI_HWVER_TYPE_PI4){
+        osc_freq = OSC_FREQ_PI4;
+    }
+
     stop_pwm(ws2811);
 
     // Setup the Clock - Use OSC @ 19.2Mhz w/ 3 clocks/tick
-    cm_clk->div = CM_CLK_DIV_PASSWD | CM_CLK_DIV_DIVI(OSC_FREQ / (3 * freq));
+    cm_clk->div = CM_CLK_DIV_PASSWD | CM_CLK_DIV_DIVI(osc_freq / (3 * freq));
     cm_clk->ctl = CM_CLK_CTL_PASSWD | CM_CLK_CTL_SRC_OSC;
     cm_clk->ctl = CM_CLK_CTL_PASSWD | CM_CLK_CTL_SRC_OSC | CM_CLK_CTL_ENAB;
     usleep(10);
@@ -422,10 +431,18 @@ static int setup_pcm(ws2811_t *ws2811)
     uint32_t freq = ws2811->freq;
     int32_t byte_count;
 
+    const rpi_hw_t *rpi_hw = ws2811->rpi_hw;
+    const uint32_t rpi_type = rpi_hw->type;
+    uint32_t osc_freq = OSC_FREQ;
+
+    if(rpi_type == RPI_HWVER_TYPE_PI4){
+        osc_freq = OSC_FREQ_PI4;
+    }
+
     stop_pcm(ws2811);
 
     // Setup the PCM Clock - Use OSC @ 19.2Mhz w/ 3 clocks/tick
-    cm_clk->div = CM_CLK_DIV_PASSWD | CM_CLK_DIV_DIVI(OSC_FREQ / (3 * freq));
+    cm_clk->div = CM_CLK_DIV_PASSWD | CM_CLK_DIV_DIVI(osc_freq / (3 * freq));
     cm_clk->ctl = CM_CLK_CTL_PASSWD | CM_CLK_CTL_SRC_OSC;
     cm_clk->ctl = CM_CLK_CTL_PASSWD | CM_CLK_CTL_SRC_OSC | CM_CLK_CTL_ENAB;
     usleep(10);

--- a/ws2811.c
+++ b/ws2811.c
@@ -56,7 +56,7 @@
 #define BUS_TO_PHYS(x)                           ((x)&~0xC0000000)
 
 #define OSC_FREQ                                 19200000   // crystal frequency
-#define OSC_FREQ_PI4                             (OSC_FREQ * 2)
+#define OSC_FREQ_PI4                             54000000   // Pi 4 crystal frequency
 
 /* 4 colors (R, G, B + W), 8 bits per byte, 3 symbols per bit + 55uS low for reset signal */
 #define LED_COLOURS                              4


### PR DESCRIPTION
I haven't confirmed if this works on all RAM variants- I've a suspicion the Revision ID will change depending on which RAM part is installed, but I'm not 100% sure.

Otherwise- this PR adds support for the Pi 4 which includes a necessary change to swap out the Oscillator Frequency, which has changed from 19.2MHz to 54MHz.

This change has been tested with Unicorn HAT using 8x8 ws2812 LEDs in original DMA->PWM mode, but not any other variants or modes.