### PR TITLE
Fix SConscript for Python 3 

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -84,7 +84,7 @@ for deb_file in debian_files:
     package_files.append(
         tools_env.Command('%s/%s' % (package_name, deb_file), deb_file, [
             Copy("$TARGET", "$SOURCE"),
-            Chmod("$TARGET", 0755)
+            Chmod("$TARGET", 0o755)
         ])
     )
 


### PR DESCRIPTION
Hi!

First, thanks for this library, great work :+1:.

## Bug

```
$ scons
scons: Reading SConscript files ...
  File "/home/alarm/rpi_ws281x/SConscript", line 87

    Chmod("$TARGET", 0755)

                        ^

SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
```

## Solution

Use Python 2/3 backward compatible octal representation with `0o` prefix (`0o755`) or use base-10 representation (`493`).

## Backward compatibilty

```python
Python 2.7.17 (default, Jan 19 2020, 19:54:54) 
[GCC 9.2.1 20200110] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 0755
493
>>> 0o755
493
>>>
```
                                                                                                                                                                                                                                                                           
```python
Python 3.7.6 (default, Jan 19 2020, 22:34:52) 
[GCC 9.2.1 20200117] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 0755
  File "<stdin>", line 1
    0755
       ^
SyntaxError: invalid token
>>> 0o755
493
>>> 
```

## References

* https://docs.python.org/3.0/whatsnew/3.0.html#integers
* https://www.python.org/dev/peps/pep-3127/#removal-of-old-octal-syntax
* https://github.com/SCons/scons/commit/41a6cedc263023c820f67a408ce46c46926116d8#diff-ce2555bbe69b610cc512e39f38430319R345
* https://scons.org/doc/3.1.2/HTML/scons-user/ch12s06.html
* https://scons.org/doc/3.1.1/HTML/scons-user/ch12s06.html (old page)
* https://python-future.org/compatible_idioms.html#octal-constants
* https://aur.archlinux.org/packages/rpi_ws281x-git#comment-718773