### PR TITLE
Basic support for spidev1.0 and SPI1 over BCM20 (Feedback Wanted)

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -693,9 +693,9 @@ static int check_hwver_and_gpionum(ws2811_t *ws2811)
 {
     const rpi_hw_t *rpi_hw;
     int hwver, gpionum;
-    int gpionums_B1[] = { 10, 20, 18, 21 };
-    int gpionums_B2[] = { 10, 20, 18, 31 };
-    int gpionums_40p[] = { 10, 20, 12, 18, 21};
+    int gpionums_B1[] = { 10, 18, 21 };
+    int gpionums_B2[] = { 10, 18, 31 };
+    int gpionums_40p[] = { 10, 12, 18, 20, 21};
     int i;
 
     rpi_hw = ws2811->rpi_hw;


### PR DESCRIPTION
Since I can't see any technical reason why it shouldn't be possible, this PR adds the necessary code to detect the use of BCM20 and switch to using /dev/spidev1.0

It's a bit rough around the edges, and could probably be accomplished more succinctly.

This requires "dtoverlay=spi1-3cs" in /boot/config.txt

My initial tests of this- without an oscilloscope or logic analyser to hand- suggest that *something* is being successfully output on SPI1, BCM20 and lighting up my 25 LEDs (or fewer if I configure it as such), but the data is mangled and the LEDs oversaturated. Additionally I'm running into https://github.com/jgarff/rpi_ws281x/issues/381, which is probably related.

Can anyone see something I've overlooked?