### PR TITLE
Clarify SPI timing issue for Pi 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ uses the PCM hardware, but you can use analog audio.
 
 #### SPI
 
-When using SPI the ledstring is the only device which can be connected to
+When using SPI the led string is the only device which can be connected to
 the SPI bus. Both digital (I2S/PCM) and analog (PWM) audio can be used.
 
 Many distributions have a maximum SPI transfer of 4096 bytes. This can be
@@ -161,11 +161,23 @@ changed in `/boot/cmdline.txt` by appending
 ```
     spidev.bufsiz=32768
 ```
-On a RPi 3 you have to change the GPU core frequency to 250 MHz, otherwise
+
+On an RPi 3 you have to change the GPU core frequency to 250 MHz, otherwise
 the SPI clock has the wrong frequency.
-Do this by adding the following line to /boot/config.txt and reboot.
+
+Do this by adding the following line to /boot/config.txt and reboot:
+
 ```
     core_freq=250
+```
+
+On an RPi 4 you must set a fixed frequency to avoid the idle CPU scaling changing the SPI frequency and breaking the ws281x timings:
+
+Do this by adding the following lines to /boot/config.txt and reboot:
+
+```
+    core_freq=500
+    core_freq_min=500
 ```
 
 SPI requires you to be in the `gpio` group if you wish to control your LEDs


### PR DESCRIPTION
This commits the findings from #381 to the documentation.

The TLDR is that the Pi 4's idle frequency scaling affects SPI, and this is fundamentally incompatible with the extremely timing sensitive hack method of driving WS281x LEDs used in this library.

Perhaps it would be possible to detect the CPU scaling frequency and dynamically adjust the SPI speed, to avoid needing to clamp it. Though I would not venture this as a priority, since power is likely not an issue when driving strands of LEDs or LED displays.