### PR TITLE
Add revision 0xD03114 for Raspberry Pi 4 Model B - 8GB support

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -97,6 +97,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 4 Model B - 4GB v1.2"
     },
+    {
+        .hwver = 0xD03114,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 8GB v1.2"
+    },
     //
     // Model B Rev 1.0
     //


### PR DESCRIPTION
I added  hardware revision 0xD03114 to rpihw.c. This solved the issues on my Raspberry Pi 4 8GB.