### PR TITLE
provide .pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,23 +48,18 @@ configure_file(version.h.in version.h)
 set(DEST_HEADERS_DIR include/ws2811)
 set(DEST_LIB_DIR lib)
 
-if(BUILD_SHARED) 
+if(BUILD_SHARED)
     add_library(${LIB_TARGET} SHARED ${LIB_SOURCES})
-    target_link_libraries(${LIB_TARGET} m)
-    set_target_properties(${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${LIB_PUBLIC_HEADERS}")
-    install(TARGETS ${LIB_TARGET} 
-        LIBRARY DESTINATION ${DEST_LIB_DIR}
-        PUBLIC_HEADER DESTINATION ${DEST_HEADERS_DIR}
-    )
 else()
     add_library(${LIB_TARGET} ${LIB_SOURCES})
-    target_link_libraries(${LIB_TARGET} m)
-    set_target_properties(${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${LIB_PUBLIC_HEADERS}")
-    install(TARGETS ${LIB_TARGET} 
-        ARCHIVE DESTINATION ${DEST_LIB_DIR}
-        PUBLIC_HEADER DESTINATION ${DEST_HEADERS_DIR}
-    )
 endif()
+
+target_link_libraries(${LIB_TARGET} m)
+set_target_properties(${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${LIB_PUBLIC_HEADERS}")
+install(TARGETS ${LIB_TARGET}
+    ARCHIVE DESTINATION ${DEST_LIB_DIR}
+    PUBLIC_HEADER DESTINATION ${DEST_HEADERS_DIR}
+)
 
 if(BUILD_TEST)
     include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ set(TEST_SOURCES
 
 configure_file(version.h.in version.h)
 
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/libws2811.pc"
+    @ONLY
+)
+
 set(DEST_HEADERS_DIR include/ws2811)
 set(DEST_LIB_DIR lib)
 
@@ -56,10 +62,14 @@ endif()
 
 target_link_libraries(${LIB_TARGET} m)
 set_target_properties(${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${LIB_PUBLIC_HEADERS}")
+
 install(TARGETS ${LIB_TARGET}
     ARCHIVE DESTINATION ${DEST_LIB_DIR}
     PUBLIC_HEADER DESTINATION ${DEST_HEADERS_DIR}
 )
+
+INSTALL(FILES "${CMAKE_BINARY_DIR}/libws2811.pc"
+        DESTINATION lib/pkgconfig)
 
 if(BUILD_TEST)
     include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/pkg-config.pc.in
+++ b/pkg-config.pc.in
@@ -1,0 +1,9 @@
+libdir="@CMAKE_INSTALL_LIBDIR@"
+includedir="@CMAKE_INSTALL_INCLUDEDIR@/ws2811"
+
+Name: libws2811
+Description: Raspberry Pi WS281X Library
+Version: 0.0.0
+Requires:
+Libs: -L${libdir} -lws2811
+Cflags: -I${includedir}


### PR DESCRIPTION
This installs a `libws2811.pc` file to `lib/pkgconfig`.

Providing a pkgconfig file simplifies the discovery of external libraries and necessary include paths, library paths etc.