### PR TITLE
Added support for Raspberry Pi 4B V1.4 4GB and 8GB

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -108,18 +108,25 @@ static const rpi_hw_t rpi_hw_info[] = {
         .desc = "Pi 4 Model B - 4GB v1.2"
     },
     {
-        .hwver = 0xD03114,
-        .type = RPI_HWVER_TYPE_PI4,
-        .periph_base = PERIPH_BASE_RPI4,
-        .videocore_base = VIDEOCORE_BASE_RPI2,
-        .desc = "Pi 4 Model B - 8GB v1.2"
-    },
-    {
         .hwver = 0xb03114,
         .type = RPI_HWVER_TYPE_PI4,
         .periph_base = PERIPH_BASE_RPI4,
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 4 Model B - 2GB v1.4"
+    },
+    {
+        .hwver = 0xD03114,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 8GB v1.4"
+    },
+    {
+        .hwver = 0xc03114,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 4GB v1.4"
     },
     //
     // Model B Rev 1.0


### PR DESCRIPTION
Added support for Raspberry Pi 4B v1.4 4GB and 8GB. Raspberry Pi 4B 8GB V1.2 version does not exist, only V1.4