### PR TITLE
Fix missing variables in pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ set(TEST_SOURCES
     main.c
 )
 
+include(GNUInstallDirs)
+
 configure_file(version.h.in version.h)
 
 configure_file(

--- a/pkg-config.pc.in
+++ b/pkg-config.pc.in
@@ -1,9 +1,9 @@
-libdir="@CMAKE_INSTALL_LIBDIR@"
-includedir="@CMAKE_INSTALL_INCLUDEDIR@/ws2811"
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/ws2811
 
 Name: libws2811
 Description: Raspberry Pi WS281X Library
-Version: 0.0.0
+Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_MICRO@
 Requires:
 Libs: -L${libdir} -lws2811
 Cflags: -I${includedir}


### PR DESCRIPTION
Fix for #456, the `ws2811.pc` file's variables were blank because CMake's [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) needs to be included to access certain `CMAKE_INSTALL_<dir>` variables.

I've also fixed the version string in the file as it was just set to 0.0.0.

I've tested this out on Ubuntu Stretch with CMake 3.20.2 as well as Raspbian Stretch with CMake 3.11.1 and they are both producing the correct file that can be used with `pkg-config`.