### PR TITLE
Support for RPi4 4GB v1.5

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -142,6 +142,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 4 Model B - 2GB v1.5"
     },
+    {
+        .hwver = 0xc03115,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 4GB v1.5"
+    },
     //
     // Compute Module 4
     //


### PR DESCRIPTION
Adds support for the 4GB pi 4 v1.5 based on the details provided in [the comment here](https://github.com/jgarff/rpi_ws281x/issues/483#issuecomment-1049815829)