### PR TITLE
Use mailbox to get hwrev

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -106,6 +106,26 @@ static int mbox_property(int file_desc, void *buf) {
     return ret_val;
 }
 
+uint32_t get_hwver(int file_desc) {
+    int i=0;
+    uint32_t p[32];
+
+    p[i++] = 0; // size
+    p[i++] = 0x00000000; // process request
+
+    p[i++] = 0x10002; // (the tag id)
+    p[i++] = 4; // (size of the buffer)
+    p[i++] = 0; // (size of the data)
+    p[i++] = 0; // (buffer)
+
+    p[i++] = 0x00000000; // end tag
+    p[0] = i*sizeof *p; // actual size
+
+    mbox_property(file_desc, p);
+
+    return p[5];
+}
+
 uint32_t mem_alloc(int file_desc, uint32_t size, uint32_t align, uint32_t flags) {
     int i=0;
     uint32_t p[32];

--- a/mailbox.h
+++ b/mailbox.h
@@ -37,6 +37,7 @@ int mbox_open(void);
 void mbox_close(int file_desc);
 
 unsigned get_version(int file_desc);
+uint32_t get_hwver(int file_desc);
 unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags);
 unsigned mem_free(int file_desc, unsigned handle);
 unsigned mem_lock(int file_desc, unsigned handle);

--- a/rpihw.h
+++ b/rpihw.h
@@ -46,7 +46,7 @@ typedef struct {
 } rpi_hw_t;
 
 
-const rpi_hw_t *rpi_hw_detect(void);
+const rpi_hw_t *rpi_hw_detect(int file_desc);
 
 
 #endif /* __RPIHW_H__ */

--- a/ws2811.c
+++ b/ws2811.c
@@ -897,13 +897,6 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     const rpi_hw_t *rpi_hw;
     int chan;
 
-    ws2811->rpi_hw = rpi_hw_detect();
-    if (!ws2811->rpi_hw)
-    {
-        return WS2811_ERROR_HW_NOT_SUPPORTED;
-    }
-    rpi_hw = ws2811->rpi_hw;
-
     ws2811->device = malloc(sizeof(*ws2811->device));
     if (!ws2811->device)
     {
@@ -911,6 +904,19 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     }
     memset(ws2811->device, 0, sizeof(*ws2811->device));
     device = ws2811->device;
+
+    device->mbox.handle = mbox_open();
+    if (device->mbox.handle == -1)
+    {
+        return WS2811_ERROR_MAILBOX_DEVICE;
+    }
+
+    ws2811->rpi_hw = rpi_hw_detect(device->mbox.handle);
+    if (!ws2811->rpi_hw)
+    {
+        return WS2811_ERROR_HW_NOT_SUPPORTED;
+    }
+    rpi_hw = ws2811->rpi_hw;
 
     if (check_hwver_and_gpionum(ws2811) < 0)
     {
@@ -937,12 +943,6 @@ ws2811_return_t ws2811_init(ws2811_t *ws2811)
     }
     // Round up to page size multiple
     device->mbox.size = (device->mbox.size + (PAGE_SIZE - 1)) & ~(PAGE_SIZE - 1);
-
-    device->mbox.handle = mbox_open();
-    if (device->mbox.handle == -1)
-    {
-        return WS2811_ERROR_MAILBOX_DEVICE;
-    }
 
     device->mbox.mem_ref = mem_alloc(device->mbox.handle, device->mbox.size, PAGE_SIZE,
                                      rpi_hw->videocore_base == 0x40000000 ? 0xC : 0x4);


### PR DESCRIPTION
I ran into some trouble using this library on my system because <reasons> (see below for details if interested).

Anyway, I was having issues with identifying the Raspberry Pi hardware platform.  Since the code is already talking to the firmware mailbox register I just switched to directly asking the firmware for the hardware revision.  I have no idea if this is a desired change or not, but to me it seems to make the code somewhat cleaner (as well as fixing my use case).  I wonder if someone had intended to do something like this previously as there is a "dangling" definition for a get_version() function in mailbox.h that has no code behind it.

Details on my issue:
I'm using Buildroot + U-Boot + RAUC to provide a system that supports safe firmware updates and a fallback rescue partition (see: https://github.com/cdsteinkuehler/br2rauc).  I'm using a 64-bit OS so I don't get the hardware details in /proc/cpuinfo.  The /system device-tree entries the existing code in rpihw.c is looking for are actually populated by the RPi firmware.  Since I load the device-tree from the selected root filesystem (allowing for kernel and device-tree updates over time) I don't have these entries in my device tree.  I may see about having my U-Boot script copy over some of these RPi firmware populated device-tree nodes, but it was quicker in the short term to just update the hardware detection logic.

Thanks for the great project!