### PR TITLE
Added rpi 1gb model 4 v1.5

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -136,6 +136,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .desc = "Pi 4 Model B - 4GB v1.4"
     },
     {
+        .hwver = 0xa03115,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 1GB v1.5"
+    },
+    {
         .hwver = 0xb03115,
         .type = RPI_HWVER_TYPE_PI4,
         .periph_base = PERIPH_BASE_RPI4,


### PR DESCRIPTION
Adding a missing Pi model type to the libraries to we can use a PiHat on a new 1gb Pi4