### PR TITLE
Correcting designator order in main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -82,16 +82,16 @@ ws2811_t ledstring =
         [0] =
         {
             .gpionum = GPIO_PIN,
-            .count = LED_COUNT,
             .invert = 0,
-            .brightness = 255,
+            .count = LED_COUNT,
             .strip_type = STRIP_TYPE,
+            .brightness = 255,
         },
         [1] =
         {
             .gpionum = 0,
-            .count = 0,
             .invert = 0,
+            .count = 0,
             .brightness = 0,
         },
     },


### PR DESCRIPTION
The designator order in main.c does not match the one defined in ws2811.h. 
This leads to problems when using the code with c++ compilers. 

- clang 13.0.0-2 emits warnings and corrects the initializations
- GCC 11.2.0 and 10.2.1 will emit an error (see issue https://github.com/jgarff/rpi_ws281x/issues/429)

I corrected the initialization order here and the compilation now works with the afromentioned complainers without issues. 
Tested on Ubuntu 21.10 (clang 13.0.0-2/gcc 11.2.0) and Raspberry Pi 4 Release 11 bullseye (GCC 10.2.1)