### PR TITLE
Add support for Compute Module 3 Rev 1.0

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -374,6 +374,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Compute Module 3+",
     },
+    {
+            .hwver  = 0xa220a0,
+            .type = RPI_HWVER_TYPE_PI2,
+            .periph_base = PERIPH_BASE_RPI2,
+            .videocore_base = VIDEOCORE_BASE_RPI2,
+            .desc = "Compute Module 3 Rev 1.0",
+    },
 
     //
     // Pi Zero


### PR DESCRIPTION
Added support for Compute Model 3 Rev 1.0 with HW version a220a0, as this was missing. 
Tested on my own device before creating this pull request.