### PR TITLE
Add a link to a Swift port to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Language-specific bindings for rpi_ws281x are available in:
 * Java - https://github.com/rpi-ws281x/rpi-ws281x-java
 * CSharp - https://github.com/rpi-ws281x/rpi-ws281x-csharp
 * Go - https://github.com/rpi-ws281x/rpi-ws281x-go
+* Swift - https://github.com/kbongort/rpi-ws281x-swift
 
 ### Background:
 


### PR DESCRIPTION
Hi, I recently made a Swift port for this library, and would like to add a link to the README. Thanks!