### PR TITLE
Add support for Pi 3 Model B Rev 1.2

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -516,6 +516,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .desc = "Pi 3 B",
     },
     {
+        .hwver  = 0xa52082,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 3 B",
+    },
+    {
         .hwver  = 0xa02082,
         .type = RPI_HWVER_TYPE_PI2,
         .periph_base = PERIPH_BASE_RPI2,


### PR DESCRIPTION
Together with a friend of mine I have added the hardware revision `0xa52082` to the list of supported Raspberry Pis. Upon first testing as dependency of [hyperion](https://github.com/hyperion-project/hyperion.ng) everything seems to work perfectly fine.