### PR TITLE
Onboard Raspberry Pi 3 Model A Plus Rev 1.1

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -549,6 +549,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .periph_base = PERIPH_BASE_RPI2,
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Model 3 A+",
+    },
+    {
+        .hwver  = 0x9020e1,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Raspberry Pi 3 Model A Plus Rev 1.1",
     }
 };
 


### PR DESCRIPTION
New version of raspberry pi is not compatible with this library, this config change makes it work locally.