### PR TITLE
Update rpihw.c to support latest Raspberry Pi 3 A+

### DIFF
--- a/rpihw.c
+++ b/rpihw.c
@@ -549,6 +549,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .periph_base = PERIPH_BASE_RPI2,
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Model 3 A+",
+    },
+    {
+        .hwver  = 0x9020e1,
+        .type = RPI_HWVER_TYPE_PI2,
+        .periph_base = PERIPH_BASE_RPI2,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Model 3 A+",
     }
 };
 


### PR DESCRIPTION
Adds the hw revision number 0x9020e1 to the list of supported devices. This was tested on a new Pi 3 A+ and verified working.