### PR TITLE
🐞 Bugfixed kernel module on newer kernels #528

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,61 @@
+###############################
+# Git Line Endings            #
+###############################
+
+# Set default behaviour to automatically normalize line endings to LF
+* text=auto eol=lf
+
+# Force batch scripts to always use CRLF line endings so that if a repo is accessed
+# in Windows via a file share from Linux, the scripts will work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf
+
+###############################
+# Git Large File System (LFS) #
+###############################
+
+# Archives
+*.7z filter=lfs diff=lfs merge=lfs -text
+*.br filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+
+# Documents
+*.pdf filter=lfs diff=lfs merge=lfs -text
+
+# Images
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+
+# Fonts
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+
+# Other
+*.exe filter=lfs diff=lfs merge=lfs -text
+
+###############################
+# Binaries                    #
+###############################
+
+# These files are binary and should be left untouched (binary is a macro for -text -diff)
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.ttf binary
+*.pyc binary
+*.so binary
+*.dat binary
+*.dll binary

--- a/rp1_ws281x_pwm/rp1_ws281x_pwm.c
+++ b/rp1_ws281x_pwm/rp1_ws281x_pwm.c
@@ -108,6 +108,19 @@ typedef struct rp1_pwm_device {
     struct page *pages[SG_CHUNK_SIZE];
 } rp1_ws281x_pwm_device_t;
 
+//---
+void rp1_ws281x_pwm_chan(int channel, int invert);
+void rp1_ws281x_pwm_init(int channel, int invert);
+void rp1_ws281x_pwm_cleanup(void);
+int rp1_ws281x_pwm_open(struct inode *inode, struct file *file);
+int rp1_ws281x_pwm_release(struct inode *inode, struct file *file);
+long rp1_ws281x_pwm_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
+void rp1_ws281x_dma_callback(void *param);
+ssize_t rp1_ws281x_dma(const char *buf, ssize_t len);
+ssize_t rp1_ws281x_pwm_write(struct file *file, const char *buf, size_t total, loff_t *loff);
+int rp1_ws281x_pwm_probe(struct platform_device *pdev);
+void rp1_ws281x_pwm_remove(struct platform_device *pdev);
+//---
 
 //
 // Global Variables
@@ -471,7 +484,7 @@ int rp1_ws281x_pwm_probe(struct platform_device *pdev) {
     return 0;
 }
 
-int rp1_ws281x_pwm_remove(struct platform_device *pdev) {
+void rp1_ws281x_pwm_remove(struct platform_device *pdev) {
     rp1_ws281x_pwm_cleanup();
 
     misc_deregister(&rp1_ws281x_pwm.mdev);
@@ -482,7 +495,7 @@ int rp1_ws281x_pwm_remove(struct platform_device *pdev) {
 
     rp1_ws281x_pwm.pdev = NULL;
 
-    return 0;
+    return;
 }
 
 static const struct of_device_id rp1_ws281x_pwm_of_match[] = {

--- a/rp1_ws281x_pwm/rp1_ws281x_pwm.dts
+++ b/rp1_ws281x_pwm/rp1_ws281x_pwm.dts
@@ -3,7 +3,7 @@
 
 / {
     fragment@0 {
-        target-path = "/axi/pcie@120000/rp1";
+        target-path = "/axi/pcie@1000120000/rp1";
 
         __overlay__ {
             #address-cells = <2>;


### PR DESCRIPTION
Part of #528

Fixes `make` compilation on newer Linux kernels, as described by @briefnotion here:
https://github.com/jgarff/rpi_ws281x/issues/528#issuecomment-2784422523

On Kernel:
- `6.6.62+rpt-rpi-2712`: I was able to `make` the kernel module without issues
- `6.12.25+rpt-rpi-2712`: I ran into `make` compilation issues and required this patch

Additionally this MR includes `.gitattributes` to enforce line endings as LF,   
which is default on Linux, thus development on Windows won't screw up the files with CRLF.
