### PR TITLE
✨ Support RPi Compute Module 5 #528

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Ignore IDE folders + VSC workspace
+**/.idea/**
+**/.vs/**
+**.code-workspace
+
+# Ignore CMake debug build folder
+cmake-build-debug/
+
 .sconsign.dblite
 version.h
 *.pyc

--- a/rpihw.c
+++ b/rpihw.c
@@ -226,6 +226,17 @@ static const rpi_hw_t rpi_hw_info[] = {
     },
 
     //
+    // Compute Module 5
+    //
+    {
+        .hwver  = 0xc04180,
+        .type = RPI_HWVER_TYPE_PI5,
+        .periph_base = 0,           // uses kernel driver
+        .videocore_base = 0,        // uses kernel driver
+        .desc = "Compute Module 5 Rev 1.0",
+    },
+
+    //
     // Model B Rev 1.0
     //
     {


### PR DESCRIPTION
Part of #528

Adds support for Raspberry Pi Compute Module 5 Rev 1.0.

Additionally this MR includes a `.gitignore` update,   
to exclude IDE + CMake debug build folders.